### PR TITLE
TestHarnessBase: remove last comma in CSV header

### DIFF
--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -268,7 +268,7 @@ public:
             const int32_t *deliveryLast = deliveryBins->getLastMarkers();
             resultMessage << " bin#,  msec,"
                           << "   wakeup#,  wlast,"
-                          << "   render#,  rlast,";
+                          << "   render#,  rlast";
             if (showDeliveryTime) {
                 resultMessage << " delivery#,  dlast";
             }


### PR DESCRIPTION
Some CSV parsers get in trouble with the last comma in the header of
the CSV histogram, so it is removed.