### PR TITLE
Linux environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: cpp
+
+script:
+  - make -f linux/Makefile
+
+install: true 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -8,6 +8,8 @@ CFLAGS = -g -Wall -Werror -Isource -std=c++11 -Ofast
 
 VPATH = apps:source:source/tools
 
+OBJECTS := $(patsubst %.cpp,%.o,$(shell find $(SOURCEDIR) -name '*.cpp'))
+
 .PHONY: default all clean
 
 default: $(TARGET)

--- a/source/tools/HostTools.h
+++ b/source/tools/HostTools.h
@@ -287,7 +287,6 @@ public:
             // Use previously measured statistics.
             double normalizedWorkUnitUtilization = cpuTiming.getNormalizedWorkUnitUtilization();
 
-            int32_t currentClockSpeedMHz =  getCpuSpeedMHz(cpuIndex);
             int32_t maxClockSpeedMHz     = getMaxCpuSpeedMHz(cpuIndex); // FIXME get from device
             const double targetUtilization = 0.8; // arbitrary
             double normalizedCurrentUtilization = currentWorkUnits * normalizedWorkUnitUtilization;

--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -51,11 +51,10 @@ public:
     , mResult(result)
     , mSampleRate(kSynthmarkSampleRate)
     , mSamplesPerFrame(2)
-    , mNumVoices(8)
     , mFrameCounter(0)
     , mDelayNotesOnUntilFrame(0)
     , mNoteCounter(0)
-
+    , mNumVoices(8)
     {
         mAudioSink = audioSink;
 


### PR DESCRIPTION
Fixed few missing things to use SynthMark on Linux targets.
Now it can be successfully compiled by using:

`$ make -f linux/Makefile`

To simplify the software development interaction, I also added a Travis-CI configuration file.