### PR TITLE
SynthMark: make more machine readable

### DIFF
--- a/apps/synthmark.cpp
+++ b/apps/synthmark.cpp
@@ -28,7 +28,6 @@
 #include "tools/VirtualAudioSink.h"
 #include "tools/VoiceMarkHarness.h"
 
-
 constexpr char kDefaultTestCode         = 'v';
 constexpr int  kDefaultSeconds          = 10;
 constexpr int  kDefaultFramesPerBurst   = 96; // 2 msec at 48000 Hz
@@ -59,6 +58,8 @@ void usage(const char *name) {
     printf("    -c{cpuAffinity} index of CPU to run on, default = UNSPECIFIED\n");
 }
 
+#define TEXT_ERROR "ERROR: "
+
 int main(int argc, char **argv)
 {
     int32_t percentCpu = kDefaultPercentCpu;
@@ -77,7 +78,7 @@ int main(int argc, char **argv)
     SynthMarkResult result;
     VirtualAudioSink audioSink;
 
-    printf("--- SynthMark V%d.%d ---\n", SYNTHMARK_MAJOR_VERSION, SYNTHMARK_MINOR_VERSION);
+    printf("# SynthMark V%d.%d\n", SYNTHMARK_MAJOR_VERSION, SYNTHMARK_MINOR_VERSION);
 
     // Parse command line arguments.
     for (int iarg = 1; iarg < argc; iarg++) {
@@ -130,54 +131,54 @@ int main(int argc, char **argv)
                     usage(argv[0]);
                     return 0;
                 default:
-                    printf("Unrecognized switch: %s\n", arg);
+                    printf(TEXT_ERROR "Unrecognized switch: %s\n", arg);
                     usage(argv[0]);
                     return 1;
             }
         } else {
-            printf("Unrecognized argument: %s\n", arg);
+            printf(TEXT_ERROR "Unrecognized argument: %s\n", arg);
             usage(argv[0]);
             return 1;
         }
     }
     if (percentCpu < 1 || percentCpu > 100) {
-        printf("Invalid percent CPU = %d\n", percentCpu);
+        printf(TEXT_ERROR "Invalid percent CPU = %d\n", percentCpu);
         usage(argv[0]);
         return 1;
     }
     if ((numVoices < 1 && numVoicesHigh <= 0)
         || numVoices < 0
         || numVoices > kSynthmarkMaxVoices) {
-        printf("Invalid num voices = %d\n", numVoices);
+        printf(TEXT_ERROR "Invalid num voices = %d\n", numVoices);
         usage(argv[0]);
         return 1;
     }
     if (numVoicesHigh != 0 && numVoicesHigh < numVoices) {
-        printf("Invalid num voices high = %d\n", numVoicesHigh);
+        printf(TEXT_ERROR "Invalid num voices high = %d\n", numVoicesHigh);
         usage(argv[0]);
         return 1;
     }
     if (numVoicesHigh != 0 && testCode != 'l') {
-        printf("Num voices high only supported for LatencyMark\n");
+        printf(TEXT_ERROR "Num voices high only supported for LatencyMark\n");
         usage(argv[0]);
         return 1;
     }
     if (voicesMode != VOICES_UNDEFINED && numVoicesHigh == 0) {
-        printf("Random voices only supported for LatencyMark\n");
+        printf(TEXT_ERROR "Random voices only supported for LatencyMark\n");
         usage(argv[0]);
         return 1;
     }
     if (numSeconds < 1) {
-        printf("Invalid duration in seconds = %d\n", numSeconds);
+        printf(TEXT_ERROR "Invalid duration in seconds = %d\n", numSeconds);
         usage(argv[0]);
         return 1;
     }
     if (numSecondsDelayNoteOn < 0 || numSecondsDelayNoteOn > numSeconds){
-        printf("Invalid delay for note on = %d\n", numSecondsDelayNoteOn);
+        printf(TEXT_ERROR "Invalid delay for note on = %d\n", numSecondsDelayNoteOn);
         return 1;
     }
     if (framesPerBurst < 4) {
-        printf("Block size too small = %d\n", framesPerBurst);
+        printf(TEXT_ERROR "Block size too small = %d\n", framesPerBurst);
         usage(argv[0]);
         return 1;
     }
@@ -213,7 +214,7 @@ int main(int argc, char **argv)
         }
             break;
         default:
-            printf("ERROR - unrecognized testCode = %c\n", testCode);
+            printf(TEXT_ERROR "unrecognized testCode = %c\n", testCode);
             usage(argv[0]);
             return 1;
             break;
@@ -222,26 +223,26 @@ int main(int argc, char **argv)
     harness->setDelayNotesOn(numSecondsDelayNoteOn);
 
     // Print specified parameters.
-    printf("  test name      = %s\n", harness->getName());
-    printf("  numVoices      = %6d\n", numVoices);
-    printf("  numVoicesHigh  = %6d\n", numVoicesHigh);
-    printf("  voicesMode     = %6d\n", voicesMode);
-    printf("  noteOnDelay    = %6d\n", numSecondsDelayNoteOn);
-    printf("  targetCpu%c     = %6d\n", '%', percentCpu);
-    printf("  framesPerBurst = %6d\n", framesPerBurst);
-    printf("  msecPerBurst   = %6.2f\n", ((framesPerBurst * 1000.0) / sampleRate));
-    printf("  cpuAffinity    = %6d\n", cpuAffinity);
-    printf("--- wait at least %d seconds for benchmark to complete ---\n", numSeconds);
+    printf("  test.mame          = %s\n", harness->getName());
+    printf("  num.voices         = %6d\n", numVoices);
+    printf("  num.voices.high    = %6d\n", numVoicesHigh);
+    printf("  voices.mode        = %6d\n", voicesMode);
+    printf("  note.on.delay      = %6d\n", numSecondsDelayNoteOn);
+    printf("  target.cpu.percent = %6d\n", '%', percentCpu);
+    printf("  frames.per.burst   = %6d\n", framesPerBurst);
+    printf("  msec.per.burst     = %6.2f\n", ((framesPerBurst * 1000.0) / sampleRate));
+    printf("  cpu.affinity       = %6d\n", cpuAffinity);
+    printf("# wait at least %d seconds for benchmark to complete\n", numSeconds);
     fflush(stdout);
 
     // Run the benchmark.
     harness->runTest(sampleRate, framesPerBurst, numSeconds);
 
     // Print the test results.
-    printf("RESULTS BEGIN\n");
+    printf(TEXT_RESULTS_BEGIN "\n");
     std::cout << result.getResultMessage();
-    printf("RESULTS END\n");
-    printf("Benchmark complete.\n");
+    printf(TEXT_RESULTS_END "\n");
+    printf("# Benchmark complete.\n");
 
     return result.getResultCode();
 }

--- a/source/SynthMark.h
+++ b/source/SynthMark.h
@@ -28,7 +28,8 @@
 // #define SYNTHMARK_MINOR_VERSION        10  /* Added CPU migration histogram */
 // #define SYNTHMARK_MINOR_VERSION        11  /* Added UtilizationMark, print Jitter after Latency */
 // #define SYNTHMARK_MINOR_VERSION        12  /* Added CPU Governor hints */
-#define SYNTHMARK_MINOR_VERSION        13  /* Default burst size changed from 64 to 96 frames */
+// #define SYNTHMARK_MINOR_VERSION        13  /* Default burst size changed from 64 to 96 frames */
+#define SYNTHMARK_MINOR_VERSION        14  /* Use more consistent report format */
 
 // This may be increased without invalidating the benchmark.
 constexpr int kSynthmarkMaxVoices   = 512;
@@ -48,5 +49,9 @@ constexpr int64_t SYNTHMARK_NANOS_PER_SECOND       = 1000000000;
 
 typedef float synth_float_t;
 
+#define TEXT_CSV_BEGIN      "CSV_BEGIN"
+#define TEXT_CSV_END        "CSV_END"
+#define TEXT_RESULTS_BEGIN  "RESULTS_BEGIN"
+#define TEXT_RESULTS_END    "RESULTS_END"
 
 #endif // SYNTHMARK_SYNTHMARK_H

--- a/source/tools/CpuAnalyzer.h
+++ b/source/tools/CpuAnalyzer.h
@@ -28,7 +28,6 @@
 #include "HostTools.h"
 #include "SynthMark.h"
 
-
 constexpr int MAX_CPUS  = 32;
 
 /**
@@ -55,15 +54,15 @@ public:
     std::string dump() {
         std::stringstream result;
         result << std::endl << "CPU Core Migration" << std::endl;
-        result << "  #migrations = " << mMigrationCount << " / " << mTotalCount;
-        int migrationPerMil = 1000 * mMigrationCount / mTotalCount;
-        result << ", migrationPerMil = " << migrationPerMil << std::endl;
+        result << "migration.count = " << mMigrationCount << std::endl;
+        result << "migration.measurements = " << mTotalCount << std::endl;
 
         // Report bins with non-zero counts.
         int32_t numBins = mCpuBins.getNumBins();
         const int32_t *cpuCounts = mCpuBins.getBins();
         const int32_t *cpuLast = mCpuBins.getLastMarkers();
-        result << " cpu#,    count,     last," << std::endl;
+        result << TEXT_CSV_BEGIN << std::endl;
+        result << " cpu#,    count,     last" << std::endl;
         for (int i = 0; i < numBins; i++) {
             if (cpuCounts[i] > 0) {
                 result << "  " << std::setw(3) << i
@@ -72,6 +71,7 @@ public:
                 << std::endl;
             }
         }
+        result << TEXT_CSV_END << std::endl;
         return result.str();
     }
 

--- a/source/tools/LatencyMarkHarness.h
+++ b/source/tools/LatencyMarkHarness.h
@@ -154,9 +154,12 @@ public:
 
         std::stringstream resultMessage;
         resultMessage << dumpJitter();
-        resultMessage << "Latency is " << sizeFrames << " frames = " << latencyMsec << " msec at burst size " <<
-                mFramesPerBurst << " frames"
-                << std::endl;
+        resultMessage << "frames.per.burst     = " << mFramesPerBurst << std::endl;
+        resultMessage << "audio.latency.bursts = " << (sizeFrames / mFramesPerBurst) << std::endl;
+        resultMessage << "audio.latency.frames = " << sizeFrames << std::endl;
+        resultMessage << "audio.latency.msec   = " << latencyMsec << std::endl;
+
+        resultMessage << mCpuAnalyzer.dump();
 
         mResult->setResultMessage(resultMessage.str());
         mResult->setResultCode(SYNTHMARK_RESULT_SUCCESS);

--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -31,7 +31,6 @@
 #include "tools/TimingAnalyzer.h"
 #include "tools/LogTool.h"
 
-
 constexpr int JITTER_BINS_PER_MSEC  = 10;
 constexpr int JITTER_MAX_MSEC       = 100;
 
@@ -260,6 +259,7 @@ public:
         BinCounter *renderBins = mTimer.getRenderBins();
         BinCounter *deliveryBins = mTimer.getDeliveryBins();
         if (wakeupBins != NULL && renderBins != NULL && deliveryBins != NULL) {
+            resultMessage << TEXT_CSV_BEGIN << std::endl;
             int32_t numBins = deliveryBins->getNumBins();
             const int32_t *wakeupCounts = wakeupBins->getBins();
             const int32_t *wakeupLast = wakeupBins->getLastMarkers();
@@ -293,6 +293,7 @@ public:
                     resultMessage << std::endl;
                 }
             }
+            resultMessage << TEXT_CSV_END << std::endl;
         } else {
             resultMessage << "ERROR NULL BinCounter!\n";
         }


### PR DESCRIPTION
Mark begin and end of CSV sections.
Use more clear key=value pairs.
Mark comment lines with #