### PR TITLE
LatencyMark: fix voice count behavior

### DIFF
--- a/source/SynthMark.h
+++ b/source/SynthMark.h
@@ -20,7 +20,6 @@
 
 // We use #define here so we can build strings easier.
 #define SYNTHMARK_MAJOR_VERSION        1
-// #define SYNTHMARK_MINOR_VERSION        5
 // #define SYNTHMARK_MINOR_VERSION        6   /* Run under OpenSL thread for SCHED_FIFO. */
 // #define SYNTHMARK_MINOR_VERSION        7   /* wakeup/render/delivery jitter */
 // #define SYNTHMARK_MINOR_VERSION        8   /* changed SYNTHMARK_FRAMES_PER_BURST from 128 => 64 */
@@ -29,7 +28,8 @@
 // #define SYNTHMARK_MINOR_VERSION        11  /* Added UtilizationMark, print Jitter after Latency */
 // #define SYNTHMARK_MINOR_VERSION        12  /* Added CPU Governor hints */
 // #define SYNTHMARK_MINOR_VERSION        13  /* Default burst size changed from 64 to 96 frames */
-#define SYNTHMARK_MINOR_VERSION        14  /* Use more consistent report format */
+// #define SYNTHMARK_MINOR_VERSION        14  /* Use more consistent report format */
+#define SYNTHMARK_MINOR_VERSION        15  /* Fix LatencyMark low-high pattern. */
 
 // This may be increased without invalidating the benchmark.
 constexpr int kSynthmarkMaxVoices   = 512;

--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -31,6 +31,7 @@
 #include "tools/LogTool.h"
 #include "tools/ITestHarness.h"
 #include "tools/TimingAnalyzer.h"
+#include "tools/TestHarnessBase.h"
 
 constexpr int JITTER_BINS_PER_MSEC  = 10;
 constexpr int JITTER_MAX_MSEC       = 100;
@@ -326,6 +327,10 @@ public:
         return mAudioSink->close();
     }
 
+    bool isVerbose() {
+        return mVerbose;
+    }
+
 protected:
     Synthesizer      mSynth;
     AudioSinkBase   *mAudioSink;
@@ -352,6 +357,7 @@ protected:
 
 private:
     int32_t          mNumVoices = 0;
+    bool             mVerbose = false;
 };
 
 #endif // SYNTHMARK_SYNTHMARK_HARNESS_H

--- a/source/tools/VoiceMarkHarness.h
+++ b/source/tools/VoiceMarkHarness.h
@@ -94,7 +94,7 @@ public:
                     accepted = true;
                 }
             }
-            mLogTool->log("%d: %3d voices used %5.3f of CPU, %s\n",
+            mLogTool->log("%2d: %3d voices used %5.3f of CPU, %s\n",
                           mBeatCount, oldNumVoices, cpuLoad,
                           accepted ? "" : " - not used");
             setNumVoices(newNumVoices);


### PR DESCRIPTION
It now always starts with the -n voice count and transitions
to the -N voice count after a few seconds. Then it repeats.
The pattern starts over with the -n count whenever a glitch is detected.

This help us consistently detect problems related to the response time
of the CPU governor.