### PR TITLE
aaudio: use AAudio thread for callback

### DIFF
--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -20,7 +20,7 @@ add_compile_options(${GCC_COVERAGE_COMPILE_FLAGS})
 # You can define multiple libraries, and CMake builds it for you.
 # Gradle automatically packages shared libraries with your APK.
 
-file(GLOB MYFILES ${SYNTHSOURCE}/*.cpp)
+file(GLOB MYFILES ${SYNTHSOURCE}/*.cpp ${SYNTHSOURCE}/aaudio/*.cpp)
 
 add_library( # Sets the name of the library.
              native-lib
@@ -34,6 +34,7 @@ add_library( # Sets the name of the library.
              src/main/cpp/native-lib.cpp
              src/main/cpp/OpenSLAudioSink.cpp
              src/main/cpp/OpenSLHostThread.cpp
+
              ${MYFILES})
 
 # Searches for a specified prebuilt library and stores the path as a
@@ -47,9 +48,11 @@ find_library( # Sets the name of the path variable.
 
               # Specifies the name of the NDK library that
               # you want CMake to locate.
-              log)
+              log
+              )
 
 find_library(opensles-lib OpenSLES)
+find_library(aaudio-lib aaudio)
 
 # Specifies libraries CMake should link to your target library. You
 # can link multiple libraries, such as libraries you define in the
@@ -62,5 +65,8 @@ target_link_libraries( # Specifies the target library.
                        # included in the NDK.
                        ${log-lib}
 
-                       ${opensles-lib})
+                       ${opensles-lib}
+                       ${aaudio-lib}
+
+                       )
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
     defaultConfig {
         applicationId "com.sonodroid.synthmark"
-        minSdkVersion 24
-        targetSdkVersion 24
+        minSdkVersion 26
+        targetSdkVersion 26
         versionCode 5
         versionName "1.5"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/cpp/OpenSLHostThread.h
+++ b/android/app/src/main/cpp/OpenSLHostThread.h
@@ -17,6 +17,7 @@
 #define ANDROID_OPENSLHOSTTHREAD_H
 
 #include "tools/HostTools.h"
+#include "tools/HostThreadFactory.h"
 #include "OpenSLAudioSink.h"
 
 /**
@@ -25,7 +26,6 @@
  */
 class OpenSLHostThread : public HostThread, IAudioSinkCallback {
 public:
-    OpenSLHostThread() {};
     virtual ~OpenSLHostThread() {};
 
     /** Start the thread and call the specified proc. */
@@ -53,8 +53,11 @@ public:
     OpenSLHostThreadFactory() {}
     virtual ~OpenSLHostThreadFactory() = default;
 
-    virtual HostThread * createThread() {
-        return (HostThread *) new OpenSLHostThread();
+    virtual HostThread * createThread(ThreadType type) {
+        if (type == ThreadType::Audio) {
+            return (HostThread *) new OpenSLHostThread();
+        }
+        return HostThreadFactory::createThread(type);
     }
 };
 #endif //ANDROID_OPENSLHOSTTHREAD_H

--- a/android_mk/jni/Android.mk
+++ b/android_mk/jni/Android.mk
@@ -6,8 +6,9 @@ LOCAL_C_INCLUDES := \
     ../source/
 LOCAL_SRC_FILES:= \
     ../../apps/synthmark.cpp \
-    ../../source/tools/HostTools.cpp
+    ../../source/tools/HostTools.cpp \
+    ../../source/aaudio/AAudioHostThread.cpp
 LOCAL_CFLAGS += -g -std=c++11 -Ofast
-#LOCAL_SHARED_LIBRARIES := libcutils libutils
+LOCAL_LDLIBS := -laaudio
 LOCAL_MODULE := synthmark
 include $(BUILD_EXECUTABLE)

--- a/android_mk/jni/Application.mk
+++ b/android_mk/jni/Application.mk
@@ -1,6 +1,7 @@
 APP_ABI := arm64-v8a
 APP_PROJECT_PATH := .
-APP_PLATFORM := android-23
-APP_STL := stlport_static
+APP_PLATFORM := android-26
+#APP_STL := stlport_static
+APP_STL := c++_static
 #APP_BUILD_SCRIPT := Android.mk
 

--- a/apps/synthmark.cpp
+++ b/apps/synthmark.cpp
@@ -58,6 +58,7 @@ void usage(const char *name) {
     printf("    -b{burstSize} frames read by virtual hardware at one time, default = %d\n",
            kDefaultFramesPerBurst);
     printf("    -c{cpuAffinity} index of CPU to run on, default = UNSPECIFIED\n");
+    printf("    -a{enable} 0 for normal thread, 1 for audio callback, default = 1\n");
 }
 
 #define TEXT_ERROR "ERROR: "
@@ -72,6 +73,7 @@ int main(int argc, char **argv)
     int32_t numVoicesHigh = 0;
     int32_t numSecondsDelayNoteOn = kDefaultNoteOnDelay;
     int32_t cpuAffinity = SYNTHMARK_CPU_UNSPECIFIED;
+    bool    useAudioThread = true;
     VoicesMode voicesMode = VOICES_UNDEFINED;
     char testCode = kDefaultTestCode;
 
@@ -87,6 +89,9 @@ int main(int argc, char **argv)
         char * arg = argv[iarg];
         if (arg[0] == '-') {
             switch(arg[1]) {
+                case 'a':
+                    useAudioThread = (atoi(&arg[2]) != 0);
+                    break;
                 case 'c':
                     cpuAffinity = atoi(&arg[2]);
                     break;
@@ -229,6 +234,9 @@ int main(int argc, char **argv)
     }
     harness->setNumVoices(numVoices);
     harness->setDelayNoteOnSeconds(numSecondsDelayNoteOn);
+    harness->setThreadType(useAudioThread
+                           ? HostThreadFactory::ThreadType::Audio
+                           : HostThreadFactory::ThreadType::Default);
 
     // Print specified parameters.
     printf("  test.name          = %s\n", harness->getName());
@@ -241,6 +249,7 @@ int main(int argc, char **argv)
     printf("  msec.per.burst     = %6.2f\n", ((framesPerBurst * 1000.0) / sampleRate));
     printf("  cpu.affinity       = %6d\n", cpuAffinity);
     printf("  cpu.count          = %6d\n", HostTools::getCpuCount());
+    printf("  audio.thread       = %6d\n", (useAudioThread ? 1 : 0));
     printf("# wait at least %d seconds for benchmark to complete\n", numSeconds);
     fflush(stdout);
 

--- a/source/SynthMark.h
+++ b/source/SynthMark.h
@@ -29,7 +29,8 @@
 // #define SYNTHMARK_MINOR_VERSION        12  /* Added CPU Governor hints */
 // #define SYNTHMARK_MINOR_VERSION        13  /* Default burst size changed from 64 to 96 frames */
 // #define SYNTHMARK_MINOR_VERSION        14  /* Use more consistent report format */
-#define SYNTHMARK_MINOR_VERSION        15  /* Fix LatencyMark low-high pattern. */
+// #define SYNTHMARK_MINOR_VERSION        15  /* Fix LatencyMark low-high pattern. */
+#define SYNTHMARK_MINOR_VERSION        16  /* Use AAudio callback thread on Android. */
 
 // This may be increased without invalidating the benchmark.
 constexpr int kSynthmarkMaxVoices   = 512;

--- a/source/aaudio/AAudioHostThread.cpp
+++ b/source/aaudio/AAudioHostThread.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#include <mutex>
+
+#include <aaudio/AAudio.h>
+#include "AAudioHostThread.h"
+
+void AAudioHostThread::callHostThread() {
+    std::lock_guard<std::mutex> lock(mDoneLock);
+    (*mProcedure)(mArgument); // This should take a long time.
+    mDone = true; // Let join() know we are done.
+}
+
+static aaudio_data_callback_result_t sm_aaudio_data_callback(
+        AAudioStream *stream __unused,
+        void *userData,
+        void *audioData __unused,
+        int32_t numFrames __unused) {
+    AAudioHostThread *hostThread = (AAudioHostThread *) userData;
+    hostThread->callHostThread();
+    return AAUDIO_CALLBACK_RESULT_STOP;
+}
+
+/** Start the thread and call the specified proc. */
+int AAudioHostThread::start(host_thread_proc_t proc, void *arg) {
+
+    mProcedure = proc;
+    mArgument = arg;
+
+    AAudioStreamBuilder *aaudioBuilder = nullptr;
+
+    // Use an AAudioStreamBuilder to contain requested parameters.
+    aaudio_result_t result = AAudio_createStreamBuilder(&aaudioBuilder);
+    if (result != AAUDIO_OK) {
+        return result;
+    }
+
+    // Request stream properties.
+    AAudioStreamBuilder_setDataCallback(aaudioBuilder, sm_aaudio_data_callback, this);
+    AAudioStreamBuilder_setPerformanceMode(aaudioBuilder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+
+    // Create an AAudioStream using the Builder.
+    result = AAudioStreamBuilder_openStream(aaudioBuilder, &mAaudioStream);
+    AAudioStreamBuilder_delete(aaudioBuilder);
+    if (result != AAUDIO_OK) {
+        return result;
+    }
+    // Start it running.
+    result = AAudioStream_requestStart(mAaudioStream);
+    if (result != AAUDIO_OK) {
+        join();
+        return result;
+    }
+    return result;
+}
+
+/** Wait for the thread proc to return. */
+int AAudioHostThread::join() {
+    AAudioStream *stream = mAaudioStream;
+    if (stream != nullptr) {
+        while (true) {
+            {
+                std::lock_guard<std::mutex> lock(mDoneLock); // will block if the thread is running
+                if (mDone) break;
+            }
+            usleep(50 * 1000); // sleep then check again
+        }
+        mAaudioStream = nullptr;
+        return AAudioStream_close(stream);
+    }
+    return AAUDIO_ERROR_INVALID_STATE;
+}

--- a/source/aaudio/AAudioHostThread.h
+++ b/source/aaudio/AAudioHostThread.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ANDROID_AAUDIOHOSTTHREAD_H
+#define ANDROID_AAUDIOHOSTTHREAD_H
+
+#include <mutex>
+
+#include <aaudio/AAudio.h>
+#include "tools/HostTools.h"
+
+/**
+ * Thread provider that uses an AAudio callback to run with SCHED_FIFO.
+ * When AAudio makes the callback, we just hijack the callback and run our benchmark.
+ */
+class AAudioHostThread : public HostThread {
+public:
+    virtual ~AAudioHostThread() {};
+
+    /** Start the thread and call the specified proc. */
+    int start(host_thread_proc_t proc, void *arg) override;
+
+    /** Wait for the thread proc to return. */
+    int join() override;
+
+    /** Try to use SCHED_FIFO. */
+    int promote(int priority) override {
+        return 0; // Nothing to do because AAudio thread starts at SCHED_FIFO.
+    }
+
+    void callHostThread();
+
+private:
+    AAudioStream       *mAaudioStream = nullptr;
+    std::mutex          mDoneLock; // Use a mutex so we can sleep on it.
+    volatile bool       mDone = false;
+};
+
+#endif //ANDROID_AAUDIOHOSTTHREAD_H

--- a/source/tools/AudioSinkBase.h
+++ b/source/tools/AudioSinkBase.h
@@ -22,6 +22,7 @@
 
 #include "IAudioSinkCallback.h"
 #include "SynthMark.h"
+#include "HostThreadFactory.h"
 
 
 #define SYNTHMARK_THREAD_PRIORITY_DEFAULT   2 // 2nd lowest priority, recommended by timmurray@
@@ -131,6 +132,14 @@ public:
     void setRequestedCpu(int cpuAffinity) {
         mRequestedCpu = cpuAffinity;
     }
+
+    virtual HostThreadFactory::ThreadType getThreadType() const {
+        return HostThreadFactory::ThreadType::Default;
+    }
+
+    virtual void setThreadType(HostThreadFactory::ThreadType mThreadType) {
+    }
+
 protected:
     void setActualCpu(int cpuAffinity) {
         mActualCpu = cpuAffinity;

--- a/source/tools/HostThreadFactory.h
+++ b/source/tools/HostThreadFactory.h
@@ -13,25 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef ANDROID_HOSTTHREADFACTORY_H
+#define ANDROID_HOSTTHREADFACTORY_H
 
-#ifndef SYNTHMARK_ITEST_HARNESS_H
-#define SYNTHMARK_ITEST_HARNESS_H
+#include <aaudio/AAudioHostThread.h>
 
-#include <cmath>
-#include <cstdint>
-
-class ITestHarness {
-
+class HostThreadFactory
+{
 public:
-    virtual void setNumVoices(int32_t numVoices) = 0;
 
-    virtual void setDelayNoteOnSeconds(int32_t seconds) = 0;
+    enum class ThreadType {
+        Default,
+        Audio
+    };
 
-    virtual const char *getName() const = 0;
-
-    virtual int32_t runTest(int32_t sampleRate, int32_t framesPerBurst, int32_t numSeconds) = 0;
-
-    virtual void setThreadType(HostThreadFactory::ThreadType mThreadType) = 0;
+    static HostThread * createThread(ThreadType type) {
+#if defined(__ANDROID__)
+        if (type == ThreadType::Audio) {
+            return new AAudioHostThread();
+        }
+#endif
+        return new HostThread();
+    }
 };
 
-#endif //SYNTHMARK_ITEST_HARNESS_H
+#endif //ANDROID_HOSTTHREADFACTORY_H

--- a/source/tools/HostTools.h
+++ b/source/tools/HostTools.h
@@ -31,7 +31,6 @@
 #include <mach/mach_time.h>
 #endif
 
-
 constexpr int64_t kNanosPerMicrosecond  = 1000;
 constexpr int64_t kNanosPerSecond       = 1000000 * kNanosPerMicrosecond;
 
@@ -115,11 +114,8 @@ typedef void * host_thread_proc_t(void *arg);
  */
 class HostThread {
 public:
-    HostThread() { }
-
-    virtual ~HostThread() {
-        join();
-    }
+    // Note that destructors should not call virtual methods.
+    virtual ~HostThread() {};
 
     virtual int start(host_thread_proc_t proc, void *arg) {
         mProcedure = proc;
@@ -156,7 +152,8 @@ public:
         struct sched_param sp;
         memset(&sp, 0, sizeof(sp));
         sp.sched_priority = priority;
-        return sched_setscheduler((pid_t) 0, SCHED_FIFO, &sp);
+        int result = sched_setscheduler((pid_t) 0, SCHED_FIFO, &sp);
+        return result;
 #endif
     }
 
@@ -189,17 +186,6 @@ protected:
     pthread_t           mPthread;
 };
 
-class HostThreadFactory
-{
-public:
-    HostThreadFactory() { }
-
-    virtual ~HostThreadFactory() = default;
-
-    virtual HostThread * createThread() {
-        return new HostThread();
-    }
-};
 
 class HostCpuManagerBase
 {

--- a/source/tools/NativeTest.h
+++ b/source/tools/NativeTest.h
@@ -181,7 +181,8 @@ public:
         VirtualAudioSink audioSink(mLogTool);
         VoiceMarkHarness harness(&audioSink, &result, mLogTool);
 
-        audioSink.setHostThread(mHostThreadFactory->createThread());
+        audioSink.setHostThread(mHostThreadFactory->createThread(
+                HostThreadFactory::ThreadType::Audio));
 
         int32_t sampleRate = mParams.getValueFromInt(PARAMS_SAMPLE_RATE);
         int32_t samplesPerFrame = mParams.getValueFromInt(PARAMS_SAMPLES_PER_FRAME);
@@ -197,8 +198,6 @@ public:
         audioSink.setRequestedCpu(CoreAffinity);
 #endif
         mLogTool->log(mParams.toString(ParamBase::PRINT_COMPACT).c_str());
-
-
 
         harness.open(sampleRate,
                      samplesPerFrame,
@@ -280,7 +279,8 @@ public:
         VirtualAudioSink audioSink(mLogTool);
         LatencyMarkHarness harness(&audioSink, &result, mLogTool);
 
-        audioSink.setHostThread(mHostThreadFactory->createThread());
+        audioSink.setHostThread(mHostThreadFactory->createThread(
+                HostThreadFactory::ThreadType::Audio));
 
         int32_t sampleRate = mParams.getValueFromInt(PARAMS_SAMPLE_RATE);
         int32_t samplesPerFrame = mParams.getValueFromInt(PARAMS_SAMPLES_PER_FRAME);
@@ -377,7 +377,8 @@ public:
         VirtualAudioSink audioSink(mLogTool);
         JitterMarkHarness harness(&audioSink, &result, mLogTool);
 
-        audioSink.setHostThread(mHostThreadFactory->createThread());
+        audioSink.setHostThread(mHostThreadFactory->createThread(
+                HostThreadFactory::ThreadType::Audio));
 
         int32_t sampleRate = mParams.getValueFromInt(PARAMS_SAMPLE_RATE);
         int32_t samplesPerFrame = mParams.getValueFromInt(PARAMS_SAMPLES_PER_FRAME);

--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -32,6 +32,7 @@
 #include "tools/ITestHarness.h"
 #include "tools/TimingAnalyzer.h"
 #include "tools/TestHarnessBase.h"
+#include "HostThreadFactory.h"
 
 constexpr int JITTER_BINS_PER_MSEC  = 10;
 constexpr int JITTER_MAX_MSEC       = 100;
@@ -286,7 +287,7 @@ public:
         mDelayNotesOnUntilFrame = (int32_t)(delayInSeconds * mSampleRate);
     }
 
-    const char *getName() override {
+    const char *getName() const override {
         return mTestName.c_str();
     }
 
@@ -329,6 +330,14 @@ public:
 
     bool isVerbose() {
         return mVerbose;
+    }
+
+    HostThreadFactory::ThreadType getThreadType() const {
+        return mAudioSink->getThreadType();
+    }
+
+    void setThreadType(HostThreadFactory::ThreadType mThreadType) override {
+        mAudioSink->setThreadType(mThreadType);
     }
 
 protected:

--- a/source/tools/VirtualAudioSink.h
+++ b/source/tools/VirtualAudioSink.h
@@ -23,6 +23,7 @@
 
 #include "AudioSinkBase.h"
 #include "HostTools.h"
+#include "HostThreadFactory.h"
 #include "LogTool.h"
 #include "SynthMark.h"
 #include "SynthMarkResult.h"
@@ -149,7 +150,7 @@ public:
         if (mUseRealThread) {
             mCallbackLoopResult = SYNTHMARK_RESULT_THREAD_FAILURE;
             if (mThread == NULL) {
-                mThread = new HostThread();
+                mThread = HostThreadFactory::createThread(mThreadType);
             }
             int err = mThread->start(threadProcWrapper, this);
             if (err != 0) {
@@ -169,6 +170,14 @@ public:
     virtual int32_t close() override {
         delete[] mBurstBuffer;
         return 0;
+    }
+
+    HostThreadFactory::ThreadType getThreadType() const override {
+        return mThreadType;
+    }
+
+    void setThreadType(HostThreadFactory::ThreadType threadType) override {
+        mThreadType = threadType;
     }
 
 private:
@@ -231,6 +240,7 @@ private:
      */
     virtual int32_t runCallbackLoop() override {
         if (mThread != NULL) {
+            printf("Try to join() mThread\n");
             int err = mThread->join();
             if (err != 0) {
                 printf("Could not join() callback thread! err = %d\n", err);
@@ -259,6 +269,9 @@ private:
     int     mThreadPriority = SYNTHMARK_THREAD_PRIORITY_DEFAULT;   // TODO control using new settings object
     int32_t mCallbackLoopResult = 0;
     HostThread * mThread = NULL;
+    HostThreadFactory::ThreadType mThreadType = HostThreadFactory::ThreadType::Audio;
+
+private:
     LogTool    * mLogTool = NULL;
 
 


### PR DESCRIPTION
So we can get BOOST mode for better performance.
This will match the thread type used by AAudio
and OpenSL ES.