### PR TITLE
synthmark: add series of utilization tests

### DIFF
--- a/apps/synthmark.cpp
+++ b/apps/synthmark.cpp
@@ -27,6 +27,7 @@
 #include "tools/LatencyMarkHarness.h"
 #include "tools/TimingAnalyzer.h"
 #include "tools/UtilizationMarkHarness.h"
+#include "tools/UtilizationSeriesHarness.h"
 #include "tools/VirtualAudioSink.h"
 #include "tools/VoiceMarkHarness.h"
 
@@ -41,7 +42,8 @@ void usage(const char *name) {
     printf("SynthMark version %d.%d\n", SYNTHMARK_MAJOR_VERSION, SYNTHMARK_MINOR_VERSION);
     printf("%s -t{test} -n{numVoices} -d{noteOnDelay} -p{percentCPU} -r{sampleRate}"
            " -s{seconds} -b{burstSize} -c{cpuAffinity}\n", name);
-    printf("    -t{test}, v=voice, l=latency, j=jitter, u=utilization, default is %c\n",
+    printf("    -t{test}, v=voice, l=latency, j=jitter, u=utilization"
+           ", s=series_util, default is %c\n",
            kDefaultTestCode);
     printf("    -n{numVoices} to render, default = %d\n", kDefaultNumVoices);
     printf("    -N{numVoices} to render for toggling high load, LatencyMark only\n");
@@ -165,11 +167,6 @@ int main(int argc, char **argv)
         usage(argv[0]);
         return 1;
     }
-    if (numVoicesHigh != 0 && testCode != 'l') {
-        printf(TEXT_ERROR "Num voices high only supported for LatencyMark\n");
-        usage(argv[0]);
-        return 1;
-    }
     if (voicesMode != VOICES_UNDEFINED && numVoicesHigh == 0) {
         printf(TEXT_ERROR "Random voices only supported for LatencyMark\n");
         usage(argv[0]);
@@ -202,6 +199,7 @@ int main(int argc, char **argv)
                 harness = voiceHarness;
             }
             break;
+
         case 'l':
             {
                 LatencyMarkHarness *latencyHarness = new LatencyMarkHarness(&audioSink, &result);
@@ -210,20 +208,32 @@ int main(int argc, char **argv)
                 harness = latencyHarness;
             }
             break;
+
         case 'j':
             harness = new JitterMarkHarness(&audioSink, &result);
             break;
+
         case 'u':
             {
-                UtilizationMarkHarness *utilizationHarness = new UtilizationMarkHarness(&audioSink, &result);
-                utilizationHarness->setNumVoices(numVoices);
+                UtilizationMarkHarness *utilizationHarness = new UtilizationMarkHarness(&audioSink,
+                                                                                        &result);
                 harness = utilizationHarness;
             }
             break;
+
         case 'a':
             {
                 AutomatedTestSuite *testSuite = new AutomatedTestSuite(&audioSink, &result);
                 harness = testSuite;
+            }
+            break;
+
+        case 's':
+            {
+                UtilizationSeriesHarness *seriesHarness = new UtilizationSeriesHarness(&audioSink,
+                                                                                       &result);
+                seriesHarness->setNumVoicesHigh(numVoicesHigh);
+                harness = seriesHarness;
             }
             break;
         default:

--- a/source/tools/AutomatedTestSuite.h
+++ b/source/tools/AutomatedTestSuite.h
@@ -25,6 +25,7 @@
 #include "tools/UtilizationMarkHarness.h"
 #include "tools/VirtualAudioSink.h"
 #include "tools/VoiceMarkHarness.h"
+#include "TestHarnessParameters.h"
 
 constexpr double kHighLowThreshold = 0.1; // Difference between CPUs to consider them BIG-little.
 constexpr double kMaxUtilization = 0.9; // Maximum load that we will push the CPU to.
@@ -42,18 +43,14 @@ constexpr double kMaxUtilization = 0.9; // Maximum load that we will push the CP
  *     assume the existence of only two architectures, homogeneous or BIG.little.
  * TODO handle more architectures.
  */
-class AutomatedTestSuite : public ITestHarness {
+class AutomatedTestSuite : public TestHarnessParameters {
 
 public:
     AutomatedTestSuite(AudioSinkBase *audioSink,
             SynthMarkResult *result,
             LogTool *logTool = nullptr)
-    : mAudioSink(audioSink)
-    , mResult(result)
-    , mLogTool(logTool)
+    : TestHarnessParameters(audioSink, result, logTool)
     {
-        setNumVoices(kSynthmarkNumVoicesLatency);
-
         // Constant seed to obtain a fixed pattern of pseudo-random voices
         // for experiment repeatability and reproducibility
         //srand(time(NULL)); // "Random" seed
@@ -61,14 +58,6 @@ public:
     }
 
     virtual ~AutomatedTestSuite() {
-    }
-
-    void setNumVoices(int32_t numVoices) override {
-        mNumVoices = numVoices;
-    }
-
-    void setDelayNoteOnSeconds(int32_t delayNotesOn) override {
-        mDelayNotesOn = delayNotesOn;
     }
 
     const char *getName() const override {
@@ -90,14 +79,6 @@ public:
         return err;
     }
 
-
-    HostThreadFactory::ThreadType getThreadType() const {
-        return mThreadType;
-    }
-
-    void setThreadType(HostThreadFactory::ThreadType threadType) override {
-        mThreadType = threadType;
-    }
 
 private:
 
@@ -270,9 +251,6 @@ private:
 
 private:
 
-    int32_t          mNumVoices = 8;
-    int32_t          mDelayNotesOn = 0;
-
     int              mBigCpu = 0;  // A CPU index in fast half of CPUs available.
     double           mVoiceMarkMaxBig = 0.0;
 
@@ -281,10 +259,6 @@ private:
 
     bool             mHaveBigLittle = false;
 
-    AudioSinkBase   *mAudioSink = nullptr;
-    SynthMarkResult *mResult = nullptr;
-    LogTool         *mLogTool = nullptr;
-    HostThreadFactory::ThreadType mThreadType = HostThreadFactory::ThreadType::Audio;
 };
 
 #endif //SYNTHMARK_AUTOMATED_TEST_SUITE_H

--- a/source/tools/JitterMarkHarness.h
+++ b/source/tools/JitterMarkHarness.h
@@ -28,6 +28,7 @@
 #include "tools/LogTool.h"
 #include "tools/TestHarnessBase.h"
 #include "tools/TimingAnalyzer.h"
+#include "TestHarnessParameters.h"
 
 
 /**

--- a/source/tools/LatencyMarkHarness.h
+++ b/source/tools/LatencyMarkHarness.h
@@ -28,6 +28,7 @@
 #include "tools/LogTool.h"
 #include "tools/TestHarnessBase.h"
 #include "tools/TimingAnalyzer.h"
+#include "TestHarnessParameters.h"
 
 
 #define NOTES_PER_STEP   10
@@ -52,7 +53,7 @@ public:
     : TestHarnessBase(audioSink, result, logTool)
     {
         mTestName = "LatencyMark";
-        setNumVoices(kSynthmarkNumVoicesLatency);
+        TestHarnessParameters::setNumVoices(kSynthmarkNumVoicesLatency);
 
         // Constant seed to obtain a fixed pattern of pseudo-random voices
         // for experiment repeatability and reproducibility
@@ -181,16 +182,8 @@ public:
         mResult->setMeasurement((double) sizeFrames);
     }
 
-    void setNumVoicesHigh(int32_t numVoicesHigh) {
-        mNumVoicesHigh = numVoicesHigh;
-    }
-
     void setVoicesMode(VoicesMode vm) {
         mVoicesMode = vm;
-    }
-
-    int32_t getNumVoicesHigh() {
-        return mNumVoicesHigh;
     }
 
     int32_t getCurrentNumVoices() override {
@@ -207,20 +200,20 @@ public:
                         // from -n.
                         lastVoices += NOTES_PER_STEP / 2;
                         if (lastVoices > mNumVoicesHigh ||
-                                lastVoices < TestHarnessBase::getNumVoices())
-                            lastVoices = TestHarnessBase::getNumVoices();
+                                lastVoices < getNumVoices())
+                            lastVoices = getNumVoices();
                         break;
                     case VOICES_RANDOM:
                         // Return a number of voices in the range [-n, -N].
-                        lastVoices = (rand() % (mNumVoicesHigh - TestHarnessBase::getNumVoices() + 1))
-                                + TestHarnessBase::getNumVoices();
+                        lastVoices = (rand() % (mNumVoicesHigh - getNumVoices() + 1))
+                                + getNumVoices();
                         break;
                     case VOICES_SWITCH:
                     default:
                         // Start low then high then low and so on.
                         // Pattern should restart on each test.
                         lastVoices = ((getNoteCounter() % NOTES_PER_STEP) < (NOTES_PER_STEP / 2))
-                                     ? TestHarnessBase::getNumVoices()
+                                     ? getNumVoices()
                                      : mNumVoicesHigh;
                         break;
                 }
@@ -231,14 +224,13 @@ public:
             }
             return lastVoices;
         } else {
-            return TestHarnessBase::getNumVoices();
+            return getNumVoices();
         }
     }
 
 private:
 
     int32_t           mPreviousUnderrunCount = 0;
-    int32_t           mNumVoicesHigh = 0;
     VoicesMode        mVoicesMode = VOICES_SWITCH;
 
     HostThread       *mMonitorThread = nullptr;

--- a/source/tools/NativeTest.h
+++ b/source/tools/NativeTest.h
@@ -31,6 +31,7 @@
 #include "TimingAnalyzer.h"
 #include "VirtualAudioSink.h"
 #include "VoiceMarkHarness.h"
+#include "TestHarnessParameters.h"
 
 #define NATIVETEST_SUCCESS 0
 #define NATIVETEST_ERROR -1

--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -56,18 +56,6 @@ public:
     , mDelayNotesOnUntilFrame(0)
     , mNoteCounter(0)
     {
-        if (!logTool) {
-            mLogTool = new LogTool(this);
-        } else {
-            mLogTool = logTool;
-        }
-    }
-
-    virtual ~TestHarnessBase() {
-        if (mLogTool && mLogTool->getOwner() == this) {
-            delete(mLogTool);
-            mLogTool = nullptr;
-        }
     }
 
     void setupJitterRecording() {

--- a/source/tools/TestHarnessBase.h
+++ b/source/tools/TestHarnessBase.h
@@ -33,6 +33,7 @@
 #include "tools/TimingAnalyzer.h"
 #include "tools/TestHarnessBase.h"
 #include "HostThreadFactory.h"
+#include "TestHarnessParameters.h"
 
 constexpr int JITTER_BINS_PER_MSEC  = 10;
 constexpr int JITTER_MAX_MSEC       = 100;
@@ -40,23 +41,20 @@ constexpr int JITTER_MAX_MSEC       = 100;
 /**
  * Base class for running a test.
  */
-class TestHarnessBase : public ITestHarness, IAudioSinkCallback {
+class TestHarnessBase : public TestHarnessParameters, IAudioSinkCallback  {
 public:
     TestHarnessBase(AudioSinkBase *audioSink,
                     SynthMarkResult *result,
                     LogTool *logTool = nullptr)
-    : mSynth()
-    , mAudioSink(audioSink)
+    : TestHarnessParameters(audioSink, result, logTool)
+    , mSynth()
     , mTimer()
     , mCpuAnalyzer()
-    , mLogTool(nullptr)
-    , mResult(result)
     , mSampleRate(kSynthmarkSampleRate)
     , mSamplesPerFrame(2)
     , mFrameCounter(0)
     , mDelayNotesOnUntilFrame(0)
     , mNoteCounter(0)
-    , mNumVoices(8)
     {
         if (!logTool) {
             mLogTool = new LogTool(this);
@@ -144,7 +142,7 @@ public:
 
         // Gather timing information.
         // mLogTool->log("renderAudio() call the synthesizer\n");
-        // Calculate time when we ideally would have woken up.
+        // Calculate time when we ideally should have woken up.
         int64_t fullFramePosition = mAudioSink->getFramesWritten()
                                     - mAudioSink->getBufferSizeInFrames()
                                     - mFramesPerBurst;
@@ -267,14 +265,6 @@ public:
     }
 
 
-    void setNumVoices(int32_t numVoices) override {
-        mNumVoices = numVoices;
-    }
-
-    int32_t getNumVoices() {
-        return mNumVoices;
-    }
-
     virtual int32_t getCurrentNumVoices() {
         return getNumVoices();
     }
@@ -342,11 +332,8 @@ public:
 
 protected:
     Synthesizer      mSynth;
-    AudioSinkBase   *mAudioSink;
     TimingAnalyzer   mTimer;
     CpuAnalyzer      mCpuAnalyzer;
-    LogTool         *mLogTool;
-    SynthMarkResult *mResult;
     std::string      mTestName;
 
     int32_t          mSampleRate = 0;
@@ -365,7 +352,6 @@ protected:
     int32_t          mBurstsOff = 0;
 
 private:
-    int32_t          mNumVoices = 0;
     bool             mVerbose = false;
 };
 

--- a/source/tools/TestHarnessParameters.h
+++ b/source/tools/TestHarnessParameters.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_TEST_HARNESS_PARAMETERS_H
+#define ANDROID_TEST_HARNESS_PARAMETERS_H
+
+#include <cstdint>
+#include "AudioSinkBase.h"
+#include "BinCounter.h"
+#include "HostTools.h"
+#include "IAudioSinkCallback.h"
+#include "SynthMarkResult.h"
+#include "synth/Synthesizer.h"
+#include "tools/CpuAnalyzer.h"
+#include "tools/LogTool.h"
+#include "tools/ITestHarness.h"
+#include "tools/TimingAnalyzer.h"
+#include "tools/TestHarnessBase.h"
+#include "HostThreadFactory.h"
+
+class TestHarnessParameters : public ITestHarness {
+
+public:
+    TestHarnessParameters(AudioSinkBase *audioSink,
+                          SynthMarkResult *result,
+                          LogTool *logTool = nullptr)
+    : mAudioSink(audioSink)
+    , mResult(result)
+    , mLogTool(logTool) {
+        setNumVoices(kSynthmarkNumVoicesLatency);
+    }
+
+    void setNumVoices(int32_t numVoices) override {
+        mNumVoices = numVoices;
+    }
+
+    int32_t getNumVoices() {
+        return mNumVoices;
+    }
+
+
+    HostThreadFactory::ThreadType getThreadType() const {
+        return mThreadType;
+    }
+
+    void setThreadType(HostThreadFactory::ThreadType threadType) override {
+        mThreadType = threadType;
+    }
+
+    void setDelayNoteOnSeconds(int32_t delayNotesOn) override {
+        mDelayNotesOn = delayNotesOn;
+    }
+
+    void setNumVoicesHigh(int32_t numVoicesHigh) {
+        mNumVoicesHigh = numVoicesHigh;
+    }
+
+    int32_t getNumVoicesHigh() {
+        return mNumVoicesHigh;
+    }
+
+protected:
+    int32_t          mNumVoices = 8;
+    int32_t          mDelayNotesOn = 0;
+    int32_t          mNumVoicesHigh = 0;
+
+    AudioSinkBase   *mAudioSink = nullptr;
+    SynthMarkResult *mResult = nullptr;
+    LogTool         *mLogTool = nullptr;
+
+    HostThreadFactory::ThreadType mThreadType = HostThreadFactory::ThreadType::Audio;
+};
+
+#endif //ANDROID_TEST_HARNESS_PARAMETERS_H

--- a/source/tools/TestHarnessParameters.h
+++ b/source/tools/TestHarnessParameters.h
@@ -41,6 +41,18 @@ public:
     , mResult(result)
     , mLogTool(logTool) {
         setNumVoices(kSynthmarkNumVoicesLatency);
+        if (!logTool) {
+            mLogTool = new LogTool(this);
+        } else {
+            mLogTool = logTool;
+        }
+    }
+
+    virtual ~TestHarnessParameters() {
+        if (mLogTool && mLogTool->getOwner() == this) {
+            delete(mLogTool);
+            mLogTool = nullptr;
+        }
     }
 
     void setNumVoices(int32_t numVoices) override {
@@ -50,7 +62,6 @@ public:
     int32_t getNumVoices() {
         return mNumVoices;
     }
-
 
     HostThreadFactory::ThreadType getThreadType() const {
         return mThreadType;

--- a/source/tools/TimingAnalyzer.h
+++ b/source/tools/TimingAnalyzer.h
@@ -55,7 +55,12 @@ public:
         mNanosPerBin = nanosPerBin;
     }
 
-    // idealTime is when the audio data was consumed
+    /**
+     * This is called soon after the audio task wakes up and right before it
+     * begins doing the audio computation.
+     *
+     * @param idealTime when the audio task should have woken up
+     */
     void markEntry(int64_t idealTime) {
         int64_t now = HostTools::getNanoTime(); // when we actually woke up
         if (mBaseTime == 0) {
@@ -74,6 +79,7 @@ public:
         }
     }
 
+    // This is called right after the audio task finishes computation.
     void markExit() {
         int64_t now = HostTools::getNanoTime();
         int64_t renderTime = now - mEntryTime;
@@ -94,13 +100,13 @@ public:
         mLoopIndex++;
     }
 
-    void recordJitter(int64_t jitterDuration) {
-        // throw away first bin
-        if (mLoopIndex > 0) {
-            int32_t binIndex = jitterDuration / mNanosPerBin;
-            mDeliveryBins->increment(binIndex);
-        }
-    }
+//    void recordJitter(int64_t jitterDuration) {
+//        // throw away first bin
+//        if (mLoopIndex > 0) {
+//            int32_t binIndex = jitterDuration / mNanosPerBin;
+//            mDeliveryBins->increment(binIndex);
+//        }
+//    }
 
     void reset() {
         mBaseTime = 0;
@@ -123,6 +129,9 @@ public:
         return mExitTime - mBaseTime;
     }
 
+    /**
+     * @return average duty cycle since the test began
+     */
     double getDutyCycle() {
         int64_t lastActivePeriod = mExitTime - mEntryTime;
         int64_t totalTime = mEntryTime - mBaseTime;

--- a/source/tools/UtilizationSeriesHarness.h
+++ b/source/tools/UtilizationSeriesHarness.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef ANDROID_UTILIZATION_SERIES_HARNESS_H
+#define ANDROID_UTILIZATION_SERIES_HARNESS_H
+
+#include "TestHarnessParameters.h"
+#include "VoiceMarkHarness.h"
+#include "UtilizationMarkHarness.h"
+
+class UtilizationSeriesHarness : public TestHarnessParameters {
+
+public:
+    UtilizationSeriesHarness(AudioSinkBase *audioSink,
+                       SynthMarkResult *result,
+                       LogTool *logTool = nullptr)
+            : TestHarnessParameters(audioSink, result, logTool) {}
+
+    virtual ~UtilizationSeriesHarness() {}
+
+    const char *getName() const override {
+        return "Utilization Series";
+    }
+
+    int32_t runTest(int32_t sampleRate, int32_t framesPerBurst, int32_t numSeconds) override {
+        int32_t err = 0;
+
+        // If user does not specify a max value then measure a reasonable one.
+        if (getNumVoicesHigh()  == 0) {
+            err = measureVoiceMark(sampleRate, framesPerBurst, numSeconds, 0.95);
+            if (err != SYNTHMARK_RESULT_SUCCESS) {
+                return err;
+            }
+            setNumVoicesHigh((int32_t) mVoiceMarkMax);
+        }
+
+        // Iterate over a range of voice counts.
+        int32_t numVoicesBegin = getNumVoices();
+        int32_t numVoicesEnd = getNumVoicesHigh();
+        int32_t range = numVoicesEnd - numVoicesBegin;
+        const int kNumSteps = 20;
+        for (int i = 0; i < kNumSteps; i++) {
+            double utilization = 0.0;
+            int32_t numVoices = numVoicesBegin + ((i * range) / (kNumSteps - 1));
+            err = measureUtilizationOnce(sampleRate, framesPerBurst,
+                                         numSeconds, numVoices,
+                                         &utilization);
+            if (err != SYNTHMARK_RESULT_SUCCESS) {
+                return err;
+            }
+            if (utilization > 0.96) {
+                break;
+            }
+        }
+        return err;
+    }
+
+    int32_t measureVoiceMark(int32_t sampleRate,
+                             int32_t framesPerBurst,
+                             int32_t numSeconds,
+                             double fractionUtilization) {
+        std::stringstream resultMessage;
+        SynthMarkResult result1;
+        VoiceMarkHarness *harness = new VoiceMarkHarness(mAudioSink, &result1);
+        harness->setTargetCpuLoad(fractionUtilization);
+        harness->setInitialVoiceCount(getNumVoices());
+        harness->setDelayNoteOnSeconds(mDelayNotesOn);
+        harness->setThreadType(mThreadType);
+
+        int32_t err = harness->runTest(sampleRate, framesPerBurst, 15);
+        delete harness;
+        if (err != SYNTHMARK_RESULT_SUCCESS) {
+            return err;
+        }
+
+        mVoiceMarkMax = result1.getMeasurement();
+
+        resultMessage << "VoiceMarkMax = " << mVoiceMarkMax << std::endl;
+
+        mResult->appendMessage(resultMessage.str());
+        return SYNTHMARK_RESULT_SUCCESS;
+    }
+
+    int32_t measureUtilizationOnce(int32_t sampleRate,
+                               int32_t framesPerBurst,
+                               int32_t numSeconds,
+                               int32_t numVoices,
+                               double *utilizationPtr) {
+        std::stringstream resultMessage;
+        SynthMarkResult result1;
+        UtilizationMarkHarness *harness = new UtilizationMarkHarness(mAudioSink, &result1);
+        harness->setNumVoices(numVoices);
+        harness->setDelayNoteOnSeconds(mDelayNotesOn);
+        harness->setThreadType(mThreadType);
+
+        int32_t err = harness->runTest(sampleRate, framesPerBurst, numSeconds);
+        delete harness;
+        if (err != SYNTHMARK_RESULT_SUCCESS) {
+            return err;
+        }
+
+        double utilization = result1.getMeasurement();
+
+        resultMessage << "utilization, " << numVoices << ", " << utilization << std::endl;
+        mResult->appendMessage(resultMessage.str());
+
+        *utilizationPtr = utilization;
+        return SYNTHMARK_RESULT_SUCCESS;
+    }
+
+    double mVoiceMarkMax = 0.0;
+};
+
+#endif //ANDROID_UTILIZATION_SERIES_HARNESS_H

--- a/source/tools/VirtualAudioSink.h
+++ b/source/tools/VirtualAudioSink.h
@@ -240,7 +240,6 @@ private:
      */
     virtual int32_t runCallbackLoop() override {
         if (mThread != NULL) {
-            printf("Try to join() mThread\n");
             int err = mThread->join();
             if (err != 0) {
                 printf("Could not join() callback thread! err = %d\n", err);

--- a/source/tools/VoiceMarkHarness.h
+++ b/source/tools/VoiceMarkHarness.h
@@ -27,6 +27,7 @@
 #include "tools/LogTool.h"
 #include "tools/TestHarnessBase.h"
 #include "tools/TimingAnalyzer.h"
+#include "TestHarnessParameters.h"
 
 
 constexpr int kMinimumVoiceCount  = 4;
@@ -60,7 +61,7 @@ public:
                         (mAudioSink->getBufferSizeInFrames() * SYNTHMARK_MILLIS_PER_SECOND)
                         / mAudioSink->getSampleRate();
         mLogTool->log("Buffer size: %.2fms\n", bufferSizeInMs);
-        setNumVoices(mInitialVoiceCount);
+        TestHarnessParameters::setNumVoices(mInitialVoiceCount);
         mSumVoicesOn = 0;
         mSumVoicesCount = 0;
         mBeatCount = 0;
@@ -97,7 +98,7 @@ public:
             mLogTool->log("%2d: %3d voices used %5.3f of CPU, %s\n",
                           mBeatCount, oldNumVoices, cpuLoad,
                           accepted ? "" : " - not used");
-            setNumVoices(newNumVoices);
+            TestHarnessParameters::setNumVoices(newNumVoices);
         }
         mTimer.reset();
         mBeatCount++;


### PR DESCRIPTION
The -ts option allow the user to request a series of utilization
benchmarks with increasing numbers of voices.
The results are printed in CSV format so that they can be easily
plotted.
The -N option can be used to set the upper limit. If not specified
then a VoiceMark95 will be run to determine the upper limit.

Test: adb shell synthmark -ts