### PR TITLE
Add UtilizationMark and ClockRamp to Android app

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="test_1">Voices</string>
     <string name="test_2">Latency</string>
     <string name="test_3">Jitter</string>
+    <string name="test_4">Utilization</string>
     <string name="test_results_title">Test results</string>
     <string name="short_update">0.0</string>
 </resources>

--- a/source/tools/LatencyMarkHarness.h
+++ b/source/tools/LatencyMarkHarness.h
@@ -45,7 +45,7 @@ public:
     : ChangingVoiceHarness(audioSink, result, logTool)
     {
         mTestName = "LatencyMark";
-        TestHarnessParameters::setNumVoices(kSynthmarkNumVoicesLatency);
+        ChangingVoiceHarness::setNumVoices(kSynthmarkNumVoicesLatency);
     }
 
     virtual ~LatencyMarkHarness() {

--- a/source/tools/TestHarnessParameters.h
+++ b/source/tools/TestHarnessParameters.h
@@ -83,6 +83,10 @@ public:
         return mNumVoicesHigh;
     }
 
+    SynthMarkResult *getResult() {
+        return mResult;
+    }
+
 protected:
     int32_t          mNumVoices = 8;
     int32_t          mDelayNotesOn = 0;

--- a/source/tools/VoiceMarkHarness.h
+++ b/source/tools/VoiceMarkHarness.h
@@ -61,7 +61,7 @@ public:
                         (mAudioSink->getBufferSizeInFrames() * SYNTHMARK_MILLIS_PER_SECOND)
                         / mAudioSink->getSampleRate();
         mLogTool->log("Buffer size: %.2fms\n", bufferSizeInMs);
-        TestHarnessParameters::setNumVoices(mInitialVoiceCount);
+        TestHarnessBase::setNumVoices(mInitialVoiceCount);
         mSumVoicesOn = 0;
         mSumVoicesCount = 0;
         mBeatCount = 0;
@@ -98,7 +98,7 @@ public:
             mLogTool->log("%2d: %3d voices used %5.3f of CPU, %s\n",
                           mBeatCount, oldNumVoices, cpuLoad,
                           accepted ? "" : " - not used");
-            TestHarnessParameters::setNumVoices(newNumVoices);
+            TestHarnessBase::setNumVoices(newNumVoices);
         }
         mTimer.reset();
         mBeatCount++;


### PR DESCRIPTION
Extract common base class TestVoiceMark and other tests.
This makes it easier to add new tests.
