### PR TITLE
Show normalized voices for UtilizationMark

### DIFF
--- a/source/tools/UtilizationMarkHarness.h
+++ b/source/tools/UtilizationMarkHarness.h
@@ -83,9 +83,10 @@ public:
         reportUtilization();
         double measurement = mFractionOfCpu;
         resultCode = SYNTHMARK_RESULT_SUCCESS;
-        resultMessage << "Underruns " << mAudioSink->getUnderrunCount() << "\n";
-        resultMessage << mTestName << " = " << measurement;
+        resultMessage << "Underruns = " << mAudioSink->getUnderrunCount() << std::endl;
+        resultMessage << mTestName << " = " << measurement << std::endl;
 
+        resultMessage << "normalized.voices.100 = " << (getNumVoices() / mFractionOfCpu) << std::endl;
         mResult->setResultCode(resultCode);
 
         resultMessage << mCpuAnalyzer.dump();

--- a/source/tools/VoiceMarkHarness.h
+++ b/source/tools/VoiceMarkHarness.h
@@ -121,10 +121,10 @@ public:
         } else {
 
             measurement = mSumVoicesOn / mSumVoicesCount;
-            resultMessage << "Underruns " << mAudioSink->getUnderrunCount() << std::endl;
+            resultMessage << "Underruns = " << mAudioSink->getUnderrunCount() << std::endl;
             resultMessage << mTestName << "_"
-                << ((int)(mFractionOfCpu * 100)) << " = " << measurement;
-            resultMessage << ", normalized to 100% = "
+                << ((int)(mFractionOfCpu * 100)) << " = " << measurement << std::endl;
+            resultMessage << "normalized.voices.100 = "
                     << (measurement / mFractionOfCpu) << std::endl;
         }
 


### PR DESCRIPTION
Also cleanup format.
And put '=' after "Underruns".