### PR TITLE
Cleanup and print average wakeup delay

### DIFF
--- a/source/tools/AudioSinkBase.h
+++ b/source/tools/AudioSinkBase.h
@@ -75,6 +75,8 @@ public:
         return mCallback->onRenderAudio(buffer, numFrames);
     }
 
+    virtual void setDefaultBufferSizeInBursts(int32_t numBursts) = 0;
+
     /**
      * Set the amount of the buffer that will be used. Determines latency.
      * @return the actual size, which may not match the requested size, or a negative error

--- a/source/tools/ClockRampHarness.h
+++ b/source/tools/ClockRampHarness.h
@@ -170,13 +170,14 @@ public:
             resultMessage << " FAIL - Never saturated the CPU. Difference in voices was too low."
                           << std::endl;
         } else {
-            double averageRampMilliss = ((double) mRampDurationSum)
+            resultMessage << " valid" << std::endl;
+            double averageRampMillis = ((double) mRampDurationSum)
                                         / (mRampDurationCount * SYNTHMARK_NANOS_PER_MILLISECOND);
-            mResult->setMeasurement(averageRampMilliss);
-            resultMessage << " = " << averageRampMilliss << " msec" << std::endl;
+            mResult->setMeasurement(averageRampMillis);
+            resultMessage << "clock.ramp.msec = " << averageRampMillis << std::endl;
         }
 
-        resultMessage << "Underruns " << mAudioSink->getUnderrunCount() << "\n";
+        resultMessage << "underrun.count = " << mAudioSink->getUnderrunCount() << "\n";
         resultMessage << mCpuAnalyzer.dump();
 
         mResult->appendMessage(resultMessage.str());

--- a/source/tools/CpuAnalyzer.h
+++ b/source/tools/CpuAnalyzer.h
@@ -44,10 +44,10 @@ public:
             mCpuBins.increment(cpuIndex);
         }
         // Did we change CPUs?
-        if (cpuIndex != mPreviousCpu) {
-            mPreviousCpu = cpuIndex;
+        if (cpuIndex != mPreviousCpu && mPreviousCpu != kCpuIndexInvalid) {
             mMigrationCount++;
         }
+        mPreviousCpu = cpuIndex;
         mTotalCount++;
     }
 
@@ -76,7 +76,9 @@ public:
     }
 
 private:
-    int         mPreviousCpu = -1;
+    static constexpr int kCpuIndexInvalid = -1;
+
+    int         mPreviousCpu = kCpuIndexInvalid;
     int32_t     mMigrationCount = 0;
     int32_t     mTotalCount = 0;
     BinCounter  mCpuBins{MAX_CPUS};

--- a/source/tools/JitterMarkHarness.h
+++ b/source/tools/JitterMarkHarness.h
@@ -62,7 +62,7 @@ public:
         resultMessage << mTestName << " = " << measurement << std::endl;
 
         resultMessage << dumpJitter();
-        resultMessage << "Underruns " << mAudioSink->getUnderrunCount() << "\n";
+        resultMessage << "underrun.count = " << mAudioSink->getUnderrunCount() << "\n";
         resultMessage << mCpuAnalyzer.dump();
 
         mResult->setMeasurement(measurement);

--- a/source/tools/LatencyMarkHarness.h
+++ b/source/tools/LatencyMarkHarness.h
@@ -85,6 +85,7 @@ public:
 
         std::stringstream resultMessage;
         resultMessage << "frames.per.burst     = " << getFramesPerBurst() << std::endl;
+        resultMessage << "# Latency values apply only to the top level buffer." << std::endl;
         resultMessage << "audio.latency.bursts = " << mLowestGoodBursts << std::endl;
         resultMessage << "audio.latency.frames = " << sizeFrames << std::endl;
         resultMessage << "audio.latency.msec   = " << latencyMsec << std::endl;

--- a/source/tools/UtilizationMarkHarness.h
+++ b/source/tools/UtilizationMarkHarness.h
@@ -83,7 +83,7 @@ public:
         reportUtilization();
         double measurement = mFractionOfCpu;
         resultCode = SYNTHMARK_RESULT_SUCCESS;
-        resultMessage << "Underruns = " << mAudioSink->getUnderrunCount() << std::endl;
+        resultMessage << "underrun.count = " << mAudioSink->getUnderrunCount() << std::endl;
         resultMessage << mTestName << " = " << measurement << std::endl;
 
         resultMessage << "normalized.voices.100 = " << (getNumVoices() / mFractionOfCpu) << std::endl;


### PR DESCRIPTION
Misc cleanup.
Set initial bursts per buffer for all tests.
Fix underrun count, which was overcounting.
Add average.wakeup.delay.micros as part of histogram.
Change various value names to use dotted format,
for example "Underruns " to underrun.count = ".