### PR TITLE
app: cleanup logs

### DIFF
--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -55,7 +55,8 @@ limitations under the License.
             <LinearLayout
                 android:orientation="vertical"
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent">
+                android:layout_height="match_parent"
+                android:background="#ffc0d0e0">
 
                 <ProgressBar
                     style="?android:attr/progressBarStyle"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,5 +10,5 @@
     <string name="test_3">Jitter</string>
     <string name="test_4">Utilization</string>
     <string name="test_results_title">Test results</string>
-    <string name="short_update">0.0</string>
+    <string name="short_update">0</string>
 </resources>

--- a/source/synth/PitchToFrequency.h
+++ b/source/synth/PitchToFrequency.h
@@ -78,7 +78,6 @@ public:
 
             lastInput = pitch;
             lastOutput = value;
-            //printf("pitch = %f, index = %d, frequency = %f\n", pitch, index, value);
         }
         return lastOutput;
     }

--- a/source/synth/Synthesizer.h
+++ b/source/synth/Synthesizer.h
@@ -59,7 +59,6 @@ public:
 
     int32_t notesOn(int32_t numVoices) {
         if (numVoices > mMaxVoices) {
-            printf("allNotesOn(%d) exceeded maxVoices of %d\n", numVoices, mMaxVoices);
             return -1;
         }
         mActiveVoiceCount = numVoices;

--- a/source/tools/AudioSinkBase.h
+++ b/source/tools/AudioSinkBase.h
@@ -19,11 +19,11 @@
 
 #include <cmath>
 #include <cstdint>
+#include <sstream>
 
 #include "IAudioSinkCallback.h"
 #include "SynthMark.h"
 #include "HostThreadFactory.h"
-
 
 #define SYNTHMARK_THREAD_PRIORITY_DEFAULT   2 // 2nd lowest priority, recommended by timmurray@
 #define SYNTHMARK_CPU_UNSPECIFIED           -1
@@ -158,6 +158,21 @@ public:
     }
 
     virtual void setThreadType(HostThreadFactory::ThreadType mThreadType) {
+    }
+
+    std::string  dump() {
+        std::stringstream resultMessage;
+        resultMessage << "AudioSink" << std::endl;
+        resultMessage << "  frames.per.burst     = " << getFramesPerBurst() << std::endl;
+        resultMessage << "  scheduler            = "
+                         << (wasSchedFifoUsed() ? "SCHED_FIFO" : "unknown") << std::endl;
+        resultMessage << "  buffer.size.frames     = "  << getBufferSizeInFrames() << std::endl;
+        resultMessage << "  buffer.size.bursts     = "
+                         << (getBufferSizeInFrames() / getFramesPerBurst()) << std::endl;
+        resultMessage << "  buffer.capacity.frames = "   << getBufferCapacityInFrames() << std::endl;
+        resultMessage << "  sample.rate            = "   << getSampleRate() << std::endl;
+        resultMessage << "  cpu.affinity           = "   << getActualCpu() << std::endl;
+        return resultMessage.str();
     }
 
 protected:

--- a/source/tools/ChangingVoiceHarness.h
+++ b/source/tools/ChangingVoiceHarness.h
@@ -74,8 +74,7 @@ public:
                 }
             }
             if (isVerbose()) {
-                printf("%s() returns %d\n", __func__, lastVoices);
-                fflush(stdout);
+                mLogTool->log("%s() returns %d\n", __func__, lastVoices);
             }
             return lastVoices;
         } else {

--- a/source/tools/HostTools.h
+++ b/source/tools/HostTools.h
@@ -90,7 +90,6 @@ public:
             } else if (microsToSleep > kMaxMicros) {
                 microsToSleep = kMaxMicros;
             }
-            //printf("Sleep for %d micros\n", microsToSleep);
             usleep(microsToSleep);
             currentTime = getNanoTime();
             nanosToSleep = wakeupTime - currentTime;

--- a/source/tools/ITestHarness.h
+++ b/source/tools/ITestHarness.h
@@ -29,7 +29,9 @@ public:
 
     virtual const char *getName() const = 0;
 
-    virtual int32_t runTest(int32_t sampleRate, int32_t framesPerBurst, int32_t numSeconds) = 0;
+    virtual int32_t runCompleteTest(int32_t sampleRate,
+                                    int32_t framesPerBurst,
+                                    int32_t numSeconds) = 0;
 
     virtual void setThreadType(HostThreadFactory::ThreadType mThreadType) = 0;
 };

--- a/source/tools/LatencyMarkHarness.h
+++ b/source/tools/LatencyMarkHarness.h
@@ -100,7 +100,7 @@ public:
         for (int i=1; i<200; i++) {
             int latency = testSearch(i);
             if (latency != i) {
-                printf("ERROR expected %d, got %d\n", i, latency);
+                mLogTool->log("ERROR expected %d, got %d\n", i, latency);
                 return 1;
             }
         }
@@ -113,7 +113,7 @@ public:
         int32_t bursts = getNextBurstsToTry(true); // assume zero latency glitches
         while (bursts > 0) {
             int32_t numSeconds = (mState == STATE_VERIFY) ? maxSeconds : std::min(maxSeconds, 10);
-            printf("LatencyMark: try #%d for %d seconds with bursts = %d -----------\n",
+            mLogTool->log("LatencyMark: try #%d for %d seconds with bursts = %d -----------\n",
                           testCount++, numSeconds, bursts);
             fflush(stdout);
             int32_t err = measureOnce(sampleRate, framesPerBurst, numSeconds);
@@ -123,7 +123,7 @@ public:
             }
             bool glitched = (mAudioSink->getUnderrunCount() > 0);
             if (!glitched) {
-                printf("LatencyMark: no glitches\n");
+                mLogTool->log("LatencyMark: no glitches\n");
             }
             bursts = getNextBurstsToTry(glitched);
             if (bursts != 0) {
@@ -157,7 +157,7 @@ public:
         if (mAudioSink->getUnderrunCount() > 0) {
             // Record when the glitch occurred.
             float glitchTime = ((float) harness.getFrameCount() / mAudioSink->getSampleRate());
-            printf("LatencyMark: detected glitch at %5.2f seconds\n", glitchTime);
+            mLogTool->log("LatencyMark: detected glitch at %5.2f seconds\n", glitchTime);
             fflush(stdout);
         }
 
@@ -185,11 +185,11 @@ public:
         resetBinarySearch();
         int32_t bursts = getNextBurstsToTry(true); // assume zero latency glitches
         while (bursts > 0) {
-            printf("%2d, ", bursts);
+            mLogTool->log("%2d, ", bursts);
             bool glitched = (bursts < target);
             bursts = getNextBurstsToTry(glitched);
         }
-        printf("\n");
+        mLogTool->log("\n");
         fflush(stdout);
         return mLowestGoodBursts;
     }

--- a/source/tools/LogTool.h
+++ b/source/tools/LogTool.h
@@ -23,7 +23,7 @@
 
 
 #define LOGTOOL_BUFFER_SIZE (10 * 1024) //max single log that can be added at once
-#define LOGTOOL_PREFIX_MAX 10
+
 class LogTool
 {
 public:
@@ -33,7 +33,6 @@ public:
         , mOStream(os)
         , mVar1(0)
     {
-        setPrefix("[Log] ");
     }
     virtual ~LogTool() {}
 
@@ -44,13 +43,11 @@ public:
         va_list args;
         va_start(args, format);
         if (mOStream) {
-            snprintf(mBuffer, LOGTOOL_BUFFER_SIZE, "%s", mPrefix);
             r = vsnprintf(mBuffer, LOGTOOL_BUFFER_SIZE, format, args);
             if (r > 0) {
                 mOStream->write(mBuffer, r);
             }
         } else {
-            printf("%s", mPrefix);
             r = std::vprintf(format, args);
         }
         va_end(args);
@@ -59,10 +56,6 @@ public:
 
     void * getOwner() {
         return mOwner;
-    }
-
-    void setPrefix(const char* prefix) {
-        strncpy(mPrefix, prefix, LOGTOOL_PREFIX_MAX);
     }
 
     void setStream(std::ostream * os) {
@@ -86,12 +79,11 @@ public:
     }
 
 private:
-    bool mEnabled;
-    void * mOwner;
+    bool          mEnabled;
+    void         *mOwner;
     std::ostream *mOStream;
-    char mBuffer[LOGTOOL_BUFFER_SIZE + 1];
-    char mPrefix[LOGTOOL_PREFIX_MAX + 1];
-    int mVar1;    //user assigned variable.
+    char          mBuffer[LOGTOOL_BUFFER_SIZE + 1];
+    int           mVar1;    //user assigned variable.
 };
 
 #endif //SYNTHMARK_LOGTOOL_H

--- a/source/tools/NativeTest.h
+++ b/source/tools/NativeTest.h
@@ -199,11 +199,14 @@ public:
         harness.setDelayNoteOnSeconds(noteOnDelay);
         harness.setThreadType(HostThreadFactory::ThreadType::Audio);
 
+        harness.runCompleteTest(sampleRate, framesPerBurst, numSeconds);
 
-        harness.runTest(sampleRate, framesPerBurst, numSeconds);
-
-        mLogTool->log(mResult.getResultMessage().c_str());
-        mLogTool->log("\n");
+        // Send one line at a time so we do not overflow the LOG buffer.
+        std::istringstream f(mResult.getResultMessage());
+        std::string line;
+        while (std::getline(f, line)) {
+            mLogTool->log((line + "\n").c_str());
+        }
 
         return SYNTHMARK_RESULT_SUCCESS;
     }
@@ -550,10 +553,10 @@ private:
     TestClockRamp        mTestClockRamp;
     TestAutomatedSuite   mTestAutomatedSuite;
 
-    LogTool mLog;
-    std::stringstream mStream;
-    HostThreadFactory mHostThreadFactoryOwned;
-    HostThreadFactory *mHostThreadFactory = NULL;
+    LogTool              mLog;
+    std::stringstream    mStream;
+    HostThreadFactory    mHostThreadFactoryOwned;
+    HostThreadFactory   *mHostThreadFactory = NULL;
 };
 
 #endif //ANDROID_NATIVETEST_H

--- a/source/tools/SynthMarkCommand.cpp
+++ b/source/tools/SynthMarkCommand.cpp
@@ -325,21 +325,10 @@ int synthmark_command_main(int argc, char **argv)
     fflush(stdout);
 
     // Run the benchmark.
-    harness->runTest(sampleRate, framesPerBurst, numSeconds);
-
-    printf("scheduler              = %s\n",  audioSink.wasSchedFifoUsed() ? "SCHED_FIFO" : "unknown");
-    printf("buffer.size.frames     = %6d\n", audioSink.getBufferSizeInFrames());
-    printf("buffer.size.bursts     = %6d\n", audioSink.getBufferSizeInFrames() / audioSink.getFramesPerBurst());
-    printf("buffer.capacity.frames = %6d\n", audioSink.getBufferCapacityInFrames());
-    printf("sample.rate            = %6d\n", audioSink.getSampleRate());
-    printf("cpu.affinity           = %6d\n", audioSink.getActualCpu());
-    fflush(stdout);
+    harness->runCompleteTest(sampleRate, framesPerBurst, numSeconds);
 
     // Print the test results.
-    printf(TEXT_RESULTS_BEGIN "\n");
     std::cout << result.getResultMessage();
-    printf(TEXT_RESULTS_END "\n");
-    printf("# Benchmark complete.\n");
 
     return result.getResultCode();
 }

--- a/source/tools/TestHarnessParameters.h
+++ b/source/tools/TestHarnessParameters.h
@@ -63,6 +63,20 @@ public:
         }
     }
 
+    virtual int32_t runTest(int32_t sampleRate,
+                                    int32_t framesPerBurst,
+                                    int32_t numSeconds) { return SYNTHMARK_RESULT_SUCCESS; };
+
+    int32_t runCompleteTest(int32_t sampleRate,
+                            int32_t framesPerBurst,
+                            int32_t numSeconds) override {
+        mResult->appendMessage(TEXT_RESULTS_BEGIN "\n");
+        int32_t result = runTest(sampleRate, framesPerBurst, numSeconds);
+        mResult->appendMessage(mAudioSink->dump());
+        mResult->appendMessage(TEXT_RESULTS_END "\n");
+        return result;
+    };
+
     void setNumVoices(int32_t numVoices) override {
         mNumVoices = numVoices;
     }

--- a/source/tools/VirtualAudioSink.h
+++ b/source/tools/VirtualAudioSink.h
@@ -104,7 +104,7 @@ public:
      * Set the amount of the buffer that will be used. Determines latency.
      */
      int32_t setBufferSizeInFrames(int32_t numFrames) override {
-        // printf("VirtualAudioSink::%s(%d) max = %d\n", __func__, numFrames, mMaxBufferCapacityInFrames);
+        // mLogTool->log("VirtualAudioSink::%s(%d) max = %d\n", __func__, numFrames, mMaxBufferCapacityInFrames);
         if (numFrames < 1) {
             numFrames = 1;
         } else if (numFrames > mMaxBufferCapacityInFrames) {
@@ -211,15 +211,15 @@ private:
                             mNanosPerBurst,
                             mNanosPerBurst);
                     if (err == 0) {
-                        printf("requestDLBandwidth(%lf)\n", initial_bw);
+                        mLogTool->log("requestDLBandwidth(%lf)\n", initial_bw);
                         fflush(stdout);
                     } else {
-                        printf("Error setting SCHED_DEADLINE\n");
-                        exit(-1);
+                        mLogTool->log("Error setting SCHED_DEADLINE\n");
+                        return -1;
                     }
                     if (getRequestedCpu() != SYNTHMARK_CPU_UNSPECIFIED) {
-                        printf("Error setting affinity for SCHED_DEADLINE task\n");
-                        exit(-1);
+                        mLogTool->log("Error setting affinity for SCHED_DEADLINE task\n");
+                        return -1;
                     }
                 } else {
                     int err = mThread->promote(mThreadPriority);
@@ -271,7 +271,7 @@ private:
         if (mThread != NULL) {
             int err = mThread->join();
             if (err != 0) {
-                printf("Could not join() callback thread! err = %d\n", err);
+                mLogTool->log("Could not join() callback thread! err = %d\n", err);
             }
             delete mThread;
             mThread = NULL;


### PR DESCRIPTION
Change some printfs to log()
Break result into lines to avoid buffer limit.
Make app and command line more similar.

Fixes #68