### PR TITLE
synthmark: fix hang at end of test

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.sonodroid.synthmark"
         minSdkVersion 26
         targetSdkVersion 26
-        versionCode 5
-        versionName "1.5"
+        versionCode 6
+        versionName "1.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/source/SynthMark.h
+++ b/source/SynthMark.h
@@ -34,7 +34,8 @@
 // #define SYNTHMARK_MINOR_VERSION        17  /* Add -N to JitterMark. */
 // #define SYNTHMARK_MINOR_VERSION        18  /* Add "-tc", ClockRamp test. Add harness to Android app. */
 // #define SYNTHMARK_MINOR_VERSION        19  /* Add -w1 for SCHED_DEADLINE. */
-#define SYNTHMARK_MINOR_VERSION        20  /* Optimize search for LatencyMark. */
+// #define SYNTHMARK_MINOR_VERSION        20  /* Optimize search for LatencyMark. */
+#define SYNTHMARK_MINOR_VERSION        21  /* Fix intermittent hang on STOP */
 
 // This may be increased without invalidating the benchmark.
 constexpr int kSynthmarkMaxVoices   = 512;

--- a/source/aaudio/AAudioHostThread.h
+++ b/source/aaudio/AAudioHostThread.h
@@ -45,8 +45,8 @@ public:
 
 private:
     AAudioStream       *mAaudioStream = nullptr;
-    std::mutex          mDoneLock; // Use a mutex so we can sleep on it.
-    volatile bool       mDone = false;
+    std::mutex          mDoneLock; // Use a mutex so we can sleep on it while join()ing.
+    std::atomic<bool>   mDone{false};
 };
 
 #endif // __ANDROID__


### PR DESCRIPTION
About a third of the time. SynthMark would hang when the test was finished.
It would then never print the test results.

This was caused by returning AAUDIO_CALLBACK_RESULT_STOP from the callback
and then immediately closing the stream. This caused a race condition.

The fix involves returning AAUDIO_CALLBACK_RESULT_CONTINUE and then preventing
the callbacks from executing the thread procedure multiple times.

Fixes #78