### PR TITLE
app: remove ProgressBar for better measurement

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.sonodroid.synthmark"
         minSdkVersion 26
         targetSdkVersion 29
-        versionCode 8
-        versionName "1.8"
+        versionCode 9
+        versionName "1.9"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/android/app/src/main/java/com/sonodroid/synthmark/AppObject.java
+++ b/android/app/src/main/java/com/sonodroid/synthmark/AppObject.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class AppObject extends Application {
     public final static String TAG = "SynthMark";
 
-    private final static int PROGRESS_REFRESH_RATE_MS = 200;
+    private final static int PROGRESS_REFRESH_RATE_MS = 300;
     private final static int PROGRESS_WARM_UP_WAIT = 300;
 
     private final static int NATIVETEST_STATUS_RUNNING = 2; //from NativeTest.h
@@ -253,6 +253,7 @@ public class AppObject extends Application {
 
         StringBuffer info = new StringBuffer();
 
+        info.append("SynthMark: " + BuildConfig.VERSION_NAME + "\n");
         info.append("Manufacturer: " + Build.MANUFACTURER + "\n");
         info.append("Model: " + Build.MODEL + "\n");
         info.append("ABI: " + Build.SUPPORTED_ABIS[0] + "\n");
@@ -333,7 +334,7 @@ public class AppObject extends Application {
 
             while (running) {
                 if (mNativeTest != 0) {
-                    updateProgressBar();
+                    // Limit the amount of progress display because it revs up the CPU.
 
                     int status = testStatus(mNativeTest);
                     if (status != NATIVETEST_STATUS_RUNNING) {
@@ -346,7 +347,6 @@ public class AppObject extends Application {
                         e.printStackTrace();
                     }
 
-
                     updateOutputReport();
                 } else {
                     break;
@@ -357,12 +357,6 @@ public class AppObject extends Application {
             wakeLock.release();
 
             return "done";
-        }
-
-        private void updateProgressBar() {
-            int progress = testProgress(mNativeTest);
-            String message = String.format("%d", progress);
-            postNotificationTestShortUpdate(mTestId, message);
         }
 
         private void updateOutputReport() {

--- a/android/app/src/main/java/com/sonodroid/synthmark/MainActivity.java
+++ b/android/app/src/main/java/com/sonodroid/synthmark/MainActivity.java
@@ -60,7 +60,6 @@ public class MainActivity extends BaseActivity {
     private View.OnClickListener mButtonListener;
     private Switch mSwitchFakeTouches;
     private FakeKeyGenerator mKeyGenerator;
-    private ProgressBar mProgressBarRunning;
     private TextView mTextViewShortUpdate;
 
     private Spinner mSpinnerTest;
@@ -89,7 +88,6 @@ public class MainActivity extends BaseActivity {
         mTextViewDeviceInfo = (TextView) findViewById(R.id.textViewDeviceInfo);
 
         mTextViewOutput = (TextView) findViewById(R.id.textViewOutput);
-        mProgressBarRunning = (ProgressBar) findViewById(R.id.progressBarRunning);
         mTextViewShortUpdate = (TextView) findViewById(R.id.textViewShortUpdate);
 
         mSwitchFakeTouches = (Switch) findViewById(R.id.switchFakeTouches);
@@ -275,7 +273,8 @@ public class MainActivity extends BaseActivity {
                 "Fake touches: " +
                 (mSwitchFakeTouches.isChecked() ? "On" : "Off") +
                 "\n");
-        mProgressBarRunning.setVisibility(View.VISIBLE);
+
+        mTextViewShortUpdate.setText("run");
 
         //disable stuff
         mButtonSettings.setEnabled(false);
@@ -306,7 +305,6 @@ public class MainActivity extends BaseActivity {
         super.notificationTestCompleted(testId);
         mKeyGenerator.stop();
         mTextViewOutput.append("Finished test " + getApp().getTestName(testId) + "\n");
-        mProgressBarRunning.setVisibility(View.INVISIBLE);
 
         //enable stuff
         mButtonSettings.setEnabled(true);

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -58,15 +58,10 @@ limitations under the License.
                 android:layout_height="match_parent"
                 android:background="#ffc0d0e0">
 
-                <ProgressBar
-                    style="?android:attr/progressBarStyle"
+                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:id="@+id/progressBarRunning"
-                    android:layout_weight="1"
-                    android:indeterminate="false"
-                    android:visibility="invisible" />
-
+                    android:text="@string/status_label" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="test_4">Utilization</string>
     <string name="test_results_title">Test results</string>
     <string name="short_update">0</string>
+    <string name="status_label">Status:</string>
 </resources>


### PR DESCRIPTION
The spinning ProgressBar was utilizing the CPU and driving up the CPU frequency.
That was affecting the measurement and causing latency to be lower.
So I removed the progress updates.

Fixes #107