### PR TITLE
Add real-time audio output.

### DIFF
--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set(SYNTHSOURCE ../../source/)
 
-SET(GCC_COVERAGE_COMPILE_FLAGS -Wall -Werror -g -std=c++11 -Ofast)
+SET(GCC_COVERAGE_COMPILE_FLAGS -Wall -Werror -g -std=c++14 -Ofast)
 
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 set(GCC_COVERAGE_COMPILE_FLAGS ${GCC_COVERAGE_COMPILE_FLAGS} -frecord-gcc-switches)

--- a/android/app/src/main/cpp/native-lib.cpp
+++ b/android/app/src/main/cpp/native-lib.cpp
@@ -20,7 +20,9 @@
 #include <android/log.h>
 
 #include "synth/IncludeMeOnce.h"
+#include "synth/IncludeMeOnce.h"
 
+#include "tools/RealAudioSink.h"
 #include "tools/NativeTest.h"
 
 JNIEXPORT jlong JNICALL

--- a/android/app/src/main/cpp/native-lib.cpp
+++ b/android/app/src/main/cpp/native-lib.cpp
@@ -20,7 +20,6 @@
 #include <android/log.h>
 
 #include "synth/IncludeMeOnce.h"
-#include "synth/IncludeMeOnce.h"
 
 #include "tools/RealAudioSink.h"
 #include "tools/NativeTest.h"

--- a/android_mk/jni/Android.mk
+++ b/android_mk/jni/Android.mk
@@ -9,7 +9,7 @@ LOCAL_SRC_FILES:= \
     ../../source/tools/HostTools.cpp \
     ../../source/tools/SynthMarkCommand.cpp \
     ../../source/aaudio/AAudioHostThread.cpp
-LOCAL_CFLAGS += -g -std=c++11 -Ofast -Wall -Werror
+LOCAL_CFLAGS += -g -std=c++14 -Ofast -Wall -Werror
 LOCAL_LDLIBS := -laaudio
 LOCAL_MODULE := synthmark
 include $(BUILD_EXECUTABLE)

--- a/source/SynthMark.h
+++ b/source/SynthMark.h
@@ -37,8 +37,8 @@
 // #define SYNTHMARK_MINOR_VERSION        20  /* Optimize search for LatencyMark. */
 // #define SYNTHMARK_MINOR_VERSION        21  /* Fix intermittent hang on STOP */
 // #define SYNTHMARK_MINOR_VERSION        22  /* Add CDD Summary to Auto Test */
-#define SYNTHMARK_MINOR_VERSION        23  /* Add UtilClamp, -f */
-
+// #define SYNTHMARK_MINOR_VERSION        23  /* Add UtilClamp -u, and SCHED_FIFO option -f */
+#define SYNTHMARK_MINOR_VERSION        24  /* Add real-time audio output using AAudio, -a2 */
 
 #define SYNTHMARK_STRINGIFY(x) #x
 #define SYNTHMARK_TOSTRING(x) SYNTHMARK_STRINGIFY(x)

--- a/source/tools/AudioSinkBase.h
+++ b/source/tools/AudioSinkBase.h
@@ -81,29 +81,41 @@ public:
         return mCallback->onRenderAudio(buffer, numFrames);
     }
 
-    virtual void setDefaultBufferSizeInBursts(int32_t numBursts) = 0;
+    void setDefaultBufferSizeInBursts(int32_t numBursts) {
+        mDefaultBufferSizeInBursts = numBursts;
+    }
 
     /**
      * Set the amount of the buffer that will be used. Determines latency.
      * @return the actual size, which may not match the requested size, or a negative error
      */
-    virtual int32_t setBufferSizeInFrames(int32_t numFrames) = 0;
+    virtual int32_t setBufferSizeInFrames(int32_t numFrames) {
+        // mLogTool.log("VirtualAudioSink::%s(%d) max = %d\n", __func__, numFrames, mBufferCapacityInFrames);
+        if (numFrames < 1) {
+            numFrames = 1;
+        } else if (numFrames > mBufferCapacityInFrames) {
+            numFrames = mBufferCapacityInFrames;
+        }
+        mBufferSizeInFrames = numFrames;
+        return mBufferSizeInFrames;
+    }
+
+    int32_t getBufferSizeInFrames() {
+        return mBufferSizeInFrames;
+    }
 
     /**
-     * Get the size size of the buffer.
+     * Get the maximum allocated size of the buffer.
      */
-    virtual int32_t getBufferSizeInFrames() = 0;
+    int32_t getBufferCapacityInFrames() {
+        return mBufferCapacityInFrames;
+    }
 
-    /**
-     * Get the maximum size of the buffer.
-     */
-    virtual int32_t getBufferCapacityInFrames() = 0;
-
-    virtual int32_t getUnderrunCount() {
+    int32_t getUnderrunCount() {
         return mUnderrunCount;
     }
 
-    virtual void setUnderrunCount(int i) {
+    void setUnderrunCount(int i) {
         mUnderrunCount = i;
     }
 
@@ -229,6 +241,12 @@ protected:
     int32_t       mUnderrunCount = 0;
     // set in callback loop
     int           mSchedulerUsed = -1;
+
+    int32_t       mBufferSizeInFrames = 0;
+// Use 2 for double buffered
+    static constexpr int kBufferSizeInBursts = 8;
+    int32_t       mDefaultBufferSizeInBursts = kBufferSizeInBursts;
+    int32_t       mBufferCapacityInFrames = 0;
 
 private:
     IAudioSinkCallback *mCallback = NULL;

--- a/source/tools/HostTools.h
+++ b/source/tools/HostTools.h
@@ -163,7 +163,7 @@ public:
      * @param cpuIndex
      * @return 0 on success or a negative errno
      */
-    virtual int setCpuAffinity(int cpuIndex) {
+    static int setCpuAffinity(int cpuIndex) {
 #if defined(__APPLE__)
         return -1;
 #else

--- a/source/tools/IAudioSinkCallback.h
+++ b/source/tools/IAudioSinkCallback.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 
-
 /**
  * Interface for a callback object that renders audio into a buffer.
  * This can be passed to an AudioSinkBase or its subclasses.

--- a/source/tools/LatencyMarkHarness.h
+++ b/source/tools/LatencyMarkHarness.h
@@ -149,7 +149,8 @@ public:
                 int32_t desiredSizeInFrames = bursts * getFramesPerBurst();
                 int32_t actualSize = mAudioSink->setBufferSizeInFrames(desiredSizeInFrames);
                 if (actualSize < desiredSizeInFrames) {
-                    mLogTool.log("ERROR - at maximum buffer size and still glitching\n");
+                    mLogTool.log("ERROR - requested buffer size %d, got %d, still glitching\n",
+                                 desiredSizeInFrames, actualSize);
                     bursts = 0;
                 }
             }

--- a/source/tools/NativeTest.h
+++ b/source/tools/NativeTest.h
@@ -234,7 +234,6 @@ protected:
 class TestVoiceMark : public CommonNativeTestUnit {
 public:
     TestVoiceMark(LogTool &logTool) : CommonNativeTestUnit("VoiceMark", logTool) {
-
     }
 
     int init() override {

--- a/source/tools/RealAudioSink.h
+++ b/source/tools/RealAudioSink.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYNTHMARK_REAL_AUDIO_SINK_H
+#define SYNTHMARK_REAL_AUDIO_SINK_H
+
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <unistd.h>
+
+#include <aaudio/AAudio.h>
+
+#include "AudioSinkBase.h"
+#include "HostTools.h"
+#include "HostThreadFactory.h"
+#include "LogTool.h"
+#include "SynthMark.h"
+#include "SynthMarkResult.h"
+#include "UtilClampAudioBehavior.h"
+#include "UtilClampController.h"
+
+class RealAudioSink : public AudioSinkBase
+{
+public:
+    RealAudioSink(LogTool &logTool)
+    : mLogTool(logTool)
+    {}
+
+    virtual ~RealAudioSink() = default;
+
+    virtual int32_t close() override {
+        if (mStream) {
+            AAudioStream_close(mStream);
+            mStream = nullptr;
+        }
+        return 0;
+    }
+
+    static aaudio_data_callback_result_t aaudio_data_callback(
+            AAudioStream *stream __unused,
+            void *userData,
+            void *audioData,
+            int32_t numFrames) {
+        RealAudioSink *audioSink = (RealAudioSink *) userData;
+        return audioSink->onCallback(audioData, numFrames);
+    }
+
+    int32_t openAAudioStream(int32_t sampleRate, int32_t samplesPerFrame) {
+        AAudioStreamBuilder *aaudioBuilder = nullptr;
+
+        // Use an AAudioStreamBuilder to contain requested parameters.
+        aaudio_result_t result = AAudio_createStreamBuilder(&aaudioBuilder);
+        if (result != AAUDIO_OK) {
+            return result;
+        }
+
+        // Request stream properties.
+        AAudioStreamBuilder_setDataCallback(aaudioBuilder, aaudio_data_callback, this);
+        AAudioStreamBuilder_setPerformanceMode(aaudioBuilder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+        //AAudioStreamBuilder_setSharingMode(aaudioBuilder, AAUDIO_SHARING_MODE_EXCLUSIVE);
+        AAudioStreamBuilder_setSharingMode(aaudioBuilder, AAUDIO_SHARING_MODE_SHARED);
+        AAudioStreamBuilder_setFormat(aaudioBuilder, AAUDIO_FORMAT_PCM_FLOAT);
+        AAudioStreamBuilder_setBufferCapacityInFrames(aaudioBuilder, 16*1024);
+
+        // Create an AAudioStream using the Builder.
+        result = AAudioStreamBuilder_openStream(aaudioBuilder, &mStream);
+        AAudioStreamBuilder_delete(aaudioBuilder);
+        if (result != AAUDIO_OK) {
+            return result;
+        }
+
+        mBufferCapacityInFrames = AAudioStream_getBufferCapacityInFrames(mStream);
+//        mLogTool.log("AAudioStream_getBufferCapacityInFrames = %d\n",
+//                     mBufferCapacityInFrames);
+
+        return (int32_t) result;
+    }
+
+    int32_t open(int32_t sampleRate, int32_t samplesPerFrame,
+            int32_t framesPerBurst) override {
+        int32_t result = openAAudioStream(sampleRate, samplesPerFrame);
+        if (result < 0) {
+            return result;
+        }
+
+        int32_t actualFramesPerBurst = AAudioStream_getFramesPerBurst(mStream);
+        if (framesPerBurst != actualFramesPerBurst) {
+            mLogTool.log("ERROR - burst mismatch, requested %d, actual = %d",
+                         framesPerBurst, actualFramesPerBurst);
+            return -1;
+        }
+
+        result = AudioSinkBase::open(sampleRate, samplesPerFrame, framesPerBurst);
+        if (result < 0) {
+            return result;
+        }
+
+        // If UNSPECIFIED then set to a reasonable default.
+        if (getBufferSizeInFrames() == 0) {
+            int32_t bufferSize = mDefaultBufferSizeInBursts * framesPerBurst;
+            setBufferSizeInFrames(bufferSize);
+        } else {
+            // Set based on previous setting.
+            setBufferSizeInFrames(getBufferSizeInFrames());
+        }
+
+        return result;
+    }
+
+    virtual int32_t start() override {
+        mThreadDone = false;
+        return AAudioStream_requestStart(mStream);
+    }
+
+    virtual int32_t stop() override {
+        return AAudioStream_requestStop(mStream);
+    }
+
+    HostThreadFactory::ThreadType getThreadType() const override {
+        return HostThreadFactory::ThreadType::Audio;
+    }
+
+    void setThreadType(HostThreadFactory::ThreadType threadType) override {
+    }
+
+    aaudio_data_callback_result_t onCallback(
+            void *audioData,
+            int32_t numFrames) {
+        aaudio_data_callback_result_t aaudioCallbackResult = AAUDIO_CALLBACK_RESULT_CONTINUE;
+        IAudioSinkCallback *callback = getCallback();
+        if (callback != NULL) {
+            if (getRequestedCpu() != SYNTHMARK_CPU_UNSPECIFIED) {
+                int err = HostThread::setCpuAffinity(getRequestedCpu());
+                if (err) {
+                    mLogTool.log("WARNING setCpuAffinity() returned %d\n", err);
+                    setActualCpu(SYNTHMARK_CPU_UNSPECIFIED);
+                } else {
+                    setActualCpu(getRequestedCpu());
+                }
+            } else {
+                setActualCpu(SYNTHMARK_CPU_UNSPECIFIED);
+            }
+
+            mSchedulerUsed = sched_getscheduler(0);
+
+            // Write in a loop until the callback says we are done.
+            IAudioSinkCallback::Result callbackResult
+                    = IAudioSinkCallback::Result::Continue;
+
+            // Call the synthesizer to render the audio data.
+            callbackResult = fireCallback((float *)audioData, mFramesPerBurst);
+            if (callbackResult != IAudioSinkCallback::Result::Continue) {
+                aaudioCallbackResult = AAUDIO_CALLBACK_RESULT_STOP;
+                mThreadDone = true;
+            }
+
+            // Update from actual AAudio underruns.
+            setUnderrunCount(AAudioStream_getXRunCount(mStream));
+        } else {
+            aaudioCallbackResult = AAUDIO_CALLBACK_RESULT_STOP;
+        }
+        return aaudioCallbackResult;
+    }
+
+
+    /**
+     * Wait for the AAudio stream to stop.
+     */
+    int32_t runCallbackLoop() override {
+        int32_t result = SYNTHMARK_RESULT_SUCCESS;
+        if (mStream) {
+            while (!mThreadDone) {
+                usleep(20 * 1000);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Set the amount of the buffer that will be used. Determines latency.
+     * @return the actual size, which may not match the requested size, or a negative error
+     */
+    int32_t setBufferSizeInFrames(int32_t numFrames) override {
+        numFrames = AudioSinkBase::setBufferSizeInFrames(numFrames);
+        if (mStream) {
+            int32_t actualSize = AAudioStream_setBufferSizeInFrames(mStream, numFrames);
+            mLogTool.log("AAudioStream_setBufferSizeInFrames(%d) = %d\n",
+                     numFrames, actualSize);
+            if (actualSize < 0) return actualSize;
+            AudioSinkBase::setBufferSizeInFrames(actualSize);
+        }
+        return AudioSinkBase::getBufferSizeInFrames();
+    }
+
+private:
+    LogTool           &mLogTool;
+    AAudioStream      *mStream = nullptr;
+    std::atomic<bool>  mThreadDone{false};
+};
+
+#endif // SYNTHMARK_REAL_AUDIO_SINK_H

--- a/source/tools/VirtualAudioSink.h
+++ b/source/tools/VirtualAudioSink.h
@@ -267,8 +267,8 @@ private:
                     if (isUtilClampLoggingEnabled()) {
                         mLogTool.log("burst, suggestedMin, actualMin, util\%, cpu\n");
                     }
-                    behavior.setup(utilClampController.getMin(),
-                                   utilClampController.getMax(),
+                    behavior.setup(40,
+                                   300,
                                    targetDurationNanos);
                 } else {
                     mLogTool.log("WARNING utilClamp not supported\n");

--- a/source/tools/VirtualAudioSink.h
+++ b/source/tools/VirtualAudioSink.h
@@ -222,6 +222,9 @@ private:
             int originalUtilClamp = 0;
             int currentUtilClamp = 0;
             constexpr int32_t kUtilClampQuanta = 10;
+            // Restrict the range to save power.
+            constexpr int32_t kUtilClampLow = 40;
+            constexpr int32_t kUtilClampHigh = 300;
             int64_t targetDurationNanos = (mFramesPerBurst * 1e9) / getSampleRate();
 
             // init UtilClampBehavior
@@ -233,8 +236,8 @@ private:
                     if (isUtilClampLoggingEnabled()) {
                         mLogTool.log("burst, suggestedMin, actualMin, util\%, cpu\n");
                     }
-                    behavior.setup(40,
-                                   300,
+                    behavior.setup(kUtilClampLow,
+                                   kUtilClampHigh,
                                    targetDurationNanos);
                 } else {
                     mLogTool.log("WARNING utilClamp not supported\n");


### PR DESCRIPTION
This allows us to test the effect of ADPF in AAudio.
Enable using -a2 option.
    
You will hear the output of the synthesized notes.
Note that more notes will sound quieter than few notes because
we divide the output by the number of notes to avoid clipping.