### PR TITLE
Support fixed uclamp_min value.

### DIFF
--- a/source/tools/AudioSinkBase.h
+++ b/source/tools/AudioSinkBase.h
@@ -179,6 +179,10 @@ public:
     }
 
     bool isUtilClampEnabled() {
+        return mUtilClampLevel > 0;
+    }
+
+    bool isUtilClampDynamic() {
         return mUtilClampLevel == UTIL_CLAMP_ON
                || mUtilClampLevel == UTIL_CLAMP_ON_LOGGED;
     }

--- a/source/tools/SynthMarkCommand.cpp
+++ b/source/tools/SynthMarkCommand.cpp
@@ -72,7 +72,7 @@ static void usage(const char *name) {
            kSynthmarkSampleRate);
     printf("    -s{seconds} to run the test, latencyMark may take longer, default is %d\n",
            kDefaultSeconds);
-    printf("    -u{utilClampLevel} 0 = off (default), 1 = on, 2 = on verbose\n");
+    printf("    -u{utilClampLevel} 0 = off (default), 1 = on, 2 = on verbose, >2 = fixed\n");
     printf("           Using utilClamp helps the scheduler adapt to dynamic workloads.\n");
     printf("    -w{workloadHintsEnabled} 0 = no (default), 1 = give workload hints to scheduler\n");
 }


### PR DESCRIPTION
Use -uM where M is >2.
Will set sched_util_min = M

Test: synthmark -tj -n1 -N75 -a1 -u0
Test: synthmark -tj -n1 -N75 -a1 -u2
Test: synthmark -tj -n1 -N75 -a1 -u165