### PR TITLE
Name C++ compiler env var properly

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -3,7 +3,6 @@
 TARGET = synthmark.app
 SOURCEDIR = source
 LIBS = -lm -lpthread
-CC = g++
 CFLAGS = -g -Wall -Werror -Isource -std=c++11 -Ofast
 
 VPATH = apps:source:source/tools
@@ -18,10 +17,10 @@ all: default
 HEADERS := $(shell find $(SOURCEDIR) -name '*.h')
 
 %.o: %.c $(HEADERS)  linux/Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 %.o: %.cpp $(HEADERS) linux/Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 .PRECIOUS: $(TARGET)
 
@@ -29,7 +28,7 @@ echo:
 	@echo $(HEADERS)
 
 %.app: %.o $(OBJECTS)
-	$(CC) $< $(OBJECTS) -Wall $(LIBS) -o $@
+	$(CXX) $< $(OBJECTS) -Wall $(LIBS) -o $@
 
 synthmark: $(TARGET)
 	./$(TARGET)


### PR DESCRIPTION
Before this change, running CC=/path/to/c-compiler CXX=/path/to/c++-compiler make -f linux/Makefile would use the C compiler instead of the C++ one. Furthermore, GNU make sets automatically CC and CXX if they were not explicitly set.